### PR TITLE
Add Diagnostic Engine v1 agent interface

### DIFF
--- a/diagnostics/diagnostic-engine-v1.schema.json
+++ b/diagnostics/diagnostic-engine-v1.schema.json
@@ -1,0 +1,117 @@
+{
+  "$id": "https://newtontech.local/schemas/diagnostic-engine-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "actual": {},
+    "blocking": {
+      "type": "boolean"
+    },
+    "category": {
+      "enum": [
+        "syntax",
+        "schema",
+        "type/value",
+        "cross-file reference",
+        "semantic consistency",
+        "preflight/runtime-risk",
+        "style/deprecation"
+      ]
+    },
+    "code": {
+      "type": "string"
+    },
+    "confidence": {
+      "maximum": 1,
+      "minimum": 0,
+      "type": "number"
+    },
+    "expected": {},
+    "file_type": {
+      "type": "string"
+    },
+    "fix_hints": {
+      "type": "array"
+    },
+    "manual_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "path": {
+      "type": "string"
+    },
+    "range": {
+      "properties": {
+        "end": {
+          "properties": {
+            "character": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        },
+        "start": {
+          "properties": {
+            "character": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "line": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "line",
+            "character"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ],
+      "type": "object"
+    },
+    "severity": {
+      "enum": [
+        "error",
+        "warning",
+        "information",
+        "hint"
+      ]
+    },
+    "software": {
+      "type": "string"
+    },
+    "source": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "code",
+    "severity",
+    "category",
+    "confidence",
+    "source",
+    "range",
+    "software",
+    "file_type",
+    "path",
+    "fix_hints",
+    "blocking"
+  ],
+  "title": "Diagnostic Engine v1 Rich Diagnostic",
+  "type": "object"
+}

--- a/docs/DIAGNOSTIC_ENGINE_V1.md
+++ b/docs/DIAGNOSTIC_ENGINE_V1.md
@@ -1,0 +1,68 @@
+# Diagnostic Engine v1
+
+This repository implements the shared newtontech Scientific LSP diagnostics
+contract inspired by python-lsp-server's provider model: the editor-facing LSP
+can keep native providers, while the agent-facing layer exposes deterministic
+JSON for check/repair/recheck loops.
+
+## Severity Policy
+
+- `error`: high-confidence syntax, schema, type/value, or reference issue that
+  should block automated submission because the upstream runtime is likely to
+  reject the input.
+- `warning`: high-risk or suspicious input that may be intentional and should
+  be shown to agents without automatically blocking repair loops.
+- `information` / `hint`: style, documentation, or optional optimization facts.
+
+## Categories
+
+- `syntax`
+- `schema`
+- `type/value`
+- `cross-file reference`
+- `semantic consistency`
+- `preflight/runtime-risk`
+- `style/deprecation`
+
+## Rich Diagnostic Shape
+
+Every agent-facing diagnostic must include:
+
+```json
+{
+  "code": "STABLE_CODE",
+  "severity": "error",
+  "category": "schema",
+  "confidence": 1.0,
+  "source": "gaussian-lsp",
+  "range": {
+    "start": {"line": 0, "character": 0},
+    "end": {"line": 0, "character": 1}
+  },
+  "software": "gaussian",
+  "file_type": "input",
+  "path": "input",
+  "expected": null,
+  "actual": null,
+  "manual_ref": null,
+  "fix_hints": [],
+  "blocking": true
+}
+```
+
+## Agent CLI
+
+Use the shared entry point:
+
+```bash
+gaussian-lsp-tool check path/to/input --format json
+gaussian-lsp-tool context path/to/input --format json
+gaussian-lsp-tool complete path/to/input --format json
+gaussian-lsp-tool hover path/to/input --format json
+gaussian-lsp-tool symbols path/to/input --format json
+gaussian-lsp-tool fix path/to/input --format json
+```
+
+`check` is wired to the existing repository diagnostics. The other operations
+reserve stable JSON shapes so downstream agents can call every LSP family with
+the same command surface while each repo fills in richer providers over time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 
 [project.scripts]
 gaussian-lsp = "gaussian_lsp.server:main"
+gaussian-lsp-tool = "gaussian_lsp.tool:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gaussian_lsp"]
@@ -72,3 +73,4 @@ exclude_lines = [
     "..."
 ]
 fail_under = 95
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,3 @@ exclude_lines = [
     "..."
 ]
 fail_under = 95
-

--- a/src/gaussian_lsp/agent_lsp.py
+++ b/src/gaussian_lsp/agent_lsp.py
@@ -1,0 +1,60 @@
+"""Small Python API wrapper around the Diagnostic Engine v1 CLI contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlparse
+
+from .rich_diagnostics import agent_check_payload
+from .tool import SOFTWARE, check_path
+
+
+class AgentLSP:
+    """Agent-facing wrapper for non-editor LSP diagnostics."""
+
+    def __init__(self, text: str | None = None, uri: str = "file:///input") -> None:
+        self.text = text
+        self.uri = uri
+
+    @classmethod
+    def from_text(cls, text: str, uri: str = "file:///input") -> "AgentLSP":
+        return cls(text=text, uri=uri)
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> "AgentLSP":
+        return cls(text=None, uri=Path(path).resolve().as_uri())
+
+    def check(self) -> dict:
+        parsed = urlparse(self.uri)
+        if self.text is None and parsed.scheme == "file":
+            return check_path(Path(parsed.path))
+        suffix = Path(parsed.path).suffix if parsed.path else ""
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / f"input{suffix}"
+            path.write_text(self.text or "", encoding="utf-8")
+            payload = check_path(path)
+            payload["uri"] = self.uri
+            return payload
+
+    def context(self, line: int = 0, character: int = 0) -> dict:
+        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="context")
+        payload["position"] = {"line": line, "character": character}
+        return payload
+
+    def complete(self, line: int = 0, character: int = 0) -> dict:
+        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="complete")
+        payload["position"] = {"line": line, "character": character}
+        payload["items"] = []
+        return payload
+
+    def hover(self, line: int = 0, character: int = 0) -> dict:
+        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="hover")
+        payload["position"] = {"line": line, "character": character}
+        payload["contents"] = None
+        return payload
+
+    def symbols(self) -> dict:
+        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="symbols")
+        payload["items"] = []
+        return payload

--- a/src/gaussian_lsp/rich_diagnostics.py
+++ b/src/gaussian_lsp/rich_diagnostics.py
@@ -1,0 +1,228 @@
+"""Diagnostic Engine v1 serialization helpers.
+
+The module keeps existing LSP/provider diagnostics untouched and provides a
+python-lsp-server-style provider boundary for agent-facing JSON consumers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Iterable
+
+
+DIAGNOSTIC_ENGINE_VERSION = "1.0"
+DIAGNOSTIC_CATEGORIES = (
+    "syntax",
+    "schema",
+    "type/value",
+    "cross-file reference",
+    "semantic consistency",
+    "preflight/runtime-risk",
+    "style/deprecation",
+)
+
+_SEVERITY_LABELS = {
+    1: "error",
+    2: "warning",
+    3: "information",
+    4: "hint",
+    "1": "error",
+    "2": "warning",
+    "3": "information",
+    "4": "hint",
+    "Error": "error",
+    "Warning": "warning",
+    "Information": "information",
+    "Hint": "hint",
+    "error": "error",
+    "warning": "warning",
+    "info": "information",
+    "information": "information",
+    "hint": "hint",
+}
+
+
+def severity_label(value: Any) -> str:
+    """Return a stable lowercase severity label."""
+    raw = getattr(value, "value", value)
+    return _SEVERITY_LABELS.get(raw, _SEVERITY_LABELS.get(str(raw), "information"))
+
+
+def infer_category(code: Any = None, message: str = "", source: str = "") -> str:
+    """Infer the Diagnostic Engine v1 category from legacy diagnostic fields."""
+    text = f"{code or ''} {message} {source}".lower()
+    if any(token in text for token in ("syntax", "parse", "parser", "token", "utf-8")):
+        return "syntax"
+    if any(token in text for token in ("unknown", "keyword", "section", "schema", "required")):
+        return "schema"
+    if any(token in text for token in ("type", "enum", "value", "integer", "float", "logical")):
+        return "type/value"
+    if any(token in text for token in ("file", "path", "include", "basis", "pseudo", "potcar", "reference")):
+        return "cross-file reference"
+    if any(token in text for token in ("deprecated", "style", "format", "indent")):
+        return "style/deprecation"
+    if any(token in text for token in ("cutoff", "scf", "memory", "parallel", "runtime", "preflight")):
+        return "preflight/runtime-risk"
+    return "semantic consistency"
+
+
+def _get_attr_or_item(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _legacy_payload(obj: Any) -> dict[str, Any]:
+    if isinstance(obj, dict):
+        return dict(obj)
+    if is_dataclass(obj):
+        return asdict(obj)
+    to_json = getattr(obj, "to_json", None)
+    if callable(to_json):
+        try:
+            value = to_json()
+            if isinstance(value, dict):
+                return dict(value)
+        except TypeError:
+            pass
+    return {}
+
+
+def _range_from_legacy(obj: Any, legacy: dict[str, Any]) -> dict[str, dict[str, int]]:
+    lsp_range = _get_attr_or_item(obj, "range")
+    if lsp_range is not None:
+        start = getattr(lsp_range, "start", None)
+        end = getattr(lsp_range, "end", None)
+        if start is not None and end is not None:
+            return {
+                "start": {
+                    "line": int(getattr(start, "line", 0) or 0),
+                    "character": int(getattr(start, "character", 0) or 0),
+                },
+                "end": {
+                    "line": int(getattr(end, "line", 0) or 0),
+                    "character": int(getattr(end, "character", 0) or 0),
+                },
+            }
+    raw_range = legacy.get("range")
+    if isinstance(raw_range, dict):
+        if "start" in raw_range and "end" in raw_range:
+            return raw_range
+        if {"start_line", "start_col", "end_line", "end_col"} <= set(raw_range):
+            return {
+                "start": {
+                    "line": int(raw_range["start_line"]),
+                    "character": int(raw_range["start_col"]),
+                },
+                "end": {
+                    "line": int(raw_range["end_line"]),
+                    "character": int(raw_range["end_col"]),
+                },
+            }
+    line = int(legacy.get("line", 1) or 1)
+    column = int(legacy.get("column", legacy.get("col", 1)) or 1)
+    line0 = max(line - 1, 0)
+    col0 = max(column - 1, 0)
+    end_col = int(legacy.get("end_col", col0 + 1) or (col0 + 1))
+    return {
+        "start": {"line": line0, "character": col0},
+        "end": {"line": line0, "character": max(end_col, col0 + 1)},
+    }
+
+
+def diagnostic_to_dict(
+    diagnostic: Any,
+    *,
+    software: str,
+    path: str = "",
+    file_type: str = "",
+) -> dict[str, Any]:
+    """Convert legacy/dataclass/LSP diagnostics into the rich v1 contract."""
+    legacy = _legacy_payload(diagnostic)
+    code = legacy.get("code", _get_attr_or_item(diagnostic, "code", "diagnostic"))
+    source = legacy.get("source", _get_attr_or_item(diagnostic, "source", f"{software}-lsp"))
+    message = legacy.get("message", _get_attr_or_item(diagnostic, "message", ""))
+    severity = severity_label(legacy.get("severity", _get_attr_or_item(diagnostic, "severity", None)))
+    confidence = float(legacy.get("confidence", 1.0) or 1.0)
+    category = legacy.get("category") or infer_category(code, message, source)
+    fix_hints = legacy.get("fix_hints")
+    if fix_hints is None:
+        suggested_fix = legacy.get("suggested_fix")
+        fix_hints = [] if suggested_fix is None else [suggested_fix]
+    blocking = bool(legacy.get("blocking", severity == "error" and confidence >= 0.8))
+    return {
+        "diagnostic_engine": DIAGNOSTIC_ENGINE_VERSION,
+        "code": str(code or "diagnostic"),
+        "severity": severity,
+        "category": category,
+        "confidence": confidence,
+        "source": str(source or f"{software}-lsp"),
+        "range": _range_from_legacy(diagnostic, legacy),
+        "software": software,
+        "file_type": file_type,
+        "path": str(legacy.get("file", path)),
+        "expected": legacy.get("expected"),
+        "actual": legacy.get("actual"),
+        "manual_ref": legacy.get("manual_ref"),
+        "fix_hints": fix_hints,
+        "blocking": blocking,
+        "message": str(message or ""),
+    }
+
+
+def serialize_diagnostics(
+    diagnostics: Iterable[Any],
+    *,
+    software: str,
+    path: str = "",
+    file_type: str = "",
+) -> list[dict[str, Any]]:
+    """Serialize diagnostics deterministically for agents and snapshots."""
+    items = [
+        diagnostic_to_dict(item, software=software, path=path, file_type=file_type)
+        for item in diagnostics
+    ]
+    return sorted(
+        items,
+        key=lambda item: (
+            item["range"]["start"]["line"],
+            item["range"]["start"]["character"],
+            item["code"],
+            item["message"],
+        ),
+    )
+
+
+def agent_check_payload(
+    *,
+    software: str,
+    uri: str,
+    operation: str = "check",
+    version: str = DIAGNOSTIC_ENGINE_VERSION,
+    diagnostics: Iterable[Any] = (),
+    path: str = "",
+    file_type: str = "",
+) -> dict[str, Any]:
+    """Build the stable top-level JSON payload returned by *-lsp-tool."""
+    items = serialize_diagnostics(
+        diagnostics,
+        software=software,
+        path=path,
+        file_type=file_type,
+    )
+    blocking_count = sum(1 for item in items if item["blocking"])
+    return {
+        "uri": uri,
+        "operation": operation,
+        "ok": blocking_count == 0,
+        "version": version,
+        "software": software,
+        "diagnostic_engine": version,
+        "diagnostics": items,
+        "summary": {
+            "count": len(items),
+            "blocking": blocking_count,
+            "errors": sum(1 for item in items if item["severity"] == "error"),
+            "warnings": sum(1 for item in items if item["severity"] == "warning"),
+        },
+    }

--- a/src/gaussian_lsp/rich_diagnostics.py
+++ b/src/gaussian_lsp/rich_diagnostics.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from dataclasses import asdict, is_dataclass
 from typing import Any, Iterable
 
-
 DIAGNOSTIC_ENGINE_VERSION = "1.0"
 DIAGNOSTIC_CATEGORIES = (
     "syntax",
@@ -57,11 +56,16 @@ def infer_category(code: Any = None, message: str = "", source: str = "") -> str
         return "schema"
     if any(token in text for token in ("type", "enum", "value", "integer", "float", "logical")):
         return "type/value"
-    if any(token in text for token in ("file", "path", "include", "basis", "pseudo", "potcar", "reference")):
+    if any(
+        token in text
+        for token in ("file", "path", "include", "basis", "pseudo", "potcar", "reference")
+    ):
         return "cross-file reference"
     if any(token in text for token in ("deprecated", "style", "format", "indent")):
         return "style/deprecation"
-    if any(token in text for token in ("cutoff", "scf", "memory", "parallel", "runtime", "preflight")):
+    if any(
+        token in text for token in ("cutoff", "scf", "memory", "parallel", "runtime", "preflight")
+    ):
         return "preflight/runtime-risk"
     return "semantic consistency"
 
@@ -142,7 +146,9 @@ def diagnostic_to_dict(
     code = legacy.get("code", _get_attr_or_item(diagnostic, "code", "diagnostic"))
     source = legacy.get("source", _get_attr_or_item(diagnostic, "source", f"{software}-lsp"))
     message = legacy.get("message", _get_attr_or_item(diagnostic, "message", ""))
-    severity = severity_label(legacy.get("severity", _get_attr_or_item(diagnostic, "severity", None)))
+    severity = severity_label(
+        legacy.get("severity", _get_attr_or_item(diagnostic, "severity", None))
+    )
     confidence = float(legacy.get("confidence", 1.0) or 1.0)
     category = legacy.get("category") or infer_category(code, message, source)
     fix_hints = legacy.get("fix_hints")

--- a/src/gaussian_lsp/rich_diagnostics.py
+++ b/src/gaussian_lsp/rich_diagnostics.py
@@ -80,7 +80,7 @@ def _legacy_payload(obj: Any) -> dict[str, Any]:
     if isinstance(obj, dict):
         return dict(obj)
     if is_dataclass(obj):
-        return asdict(obj)
+        return asdict(obj)  # type: ignore[arg-type]
     to_json = getattr(obj, "to_json", None)
     if callable(to_json):
         try:

--- a/src/gaussian_lsp/tool.py
+++ b/src/gaussian_lsp/tool.py
@@ -1,0 +1,81 @@
+"""Agent-facing CLI for Diagnostic Engine v1 operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .rich_diagnostics import agent_check_payload
+
+SOFTWARE = "gaussian"
+
+
+def _file_type(path: Path) -> str:
+    name = path.name.upper()
+    if name in {"INCAR", "POSCAR", "KPOINTS", "POTCAR", "CONTCAR"}:
+        return name
+    if "." in path.name:
+        return path.suffix.lstrip(".").lower()
+    return name.lower()
+
+
+def _collect_diagnostics(path: Path) -> list[Any]:
+    from .features.diagnostic import DiagnosticProvider
+    from .features.lint import LintProvider
+    from .features.typecheck import TypecheckProvider
+
+    text = path.read_text(encoding="utf-8")
+    diagnostics = list(DiagnosticProvider(None).get_diagnostics(text))  # type: ignore[arg-type]
+    diagnostics.extend(LintProvider(None).lint(text))  # type: ignore[arg-type]
+    diagnostics.extend(TypecheckProvider().validate(text))
+    return diagnostics
+
+
+def check_path(path: Path) -> dict[str, Any]:
+    uri = path.resolve().as_uri()
+    diagnostics = _collect_diagnostics(path)
+    return agent_check_payload(
+        software=SOFTWARE,
+        uri=uri,
+        operation="check",
+        diagnostics=diagnostics,
+        path=str(path),
+        file_type=_file_type(path),
+    )
+
+
+def _empty_operation(path: Path, operation: str) -> dict[str, Any]:
+    payload = agent_check_payload(
+        software=SOFTWARE,
+        uri=path.resolve().as_uri(),
+        operation=operation,
+        diagnostics=[],
+        path=str(path),
+        file_type=_file_type(path),
+    )
+    payload["summary"]["note"] = f"{operation} is reserved by the Diagnostic Engine v1 CLI contract"
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="gaussian-lsp-tool")
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+    for operation in ("check", "context", "complete", "hover", "symbols", "fix"):
+        sub = subparsers.add_parser(operation)
+        sub.add_argument("path", type=Path)
+        sub.add_argument("--format", choices=["json"], default="json")
+        if operation == "check":
+            sub.add_argument("--fail-on-blocking", action="store_true")
+    args = parser.parse_args(argv)
+    if args.operation == "check":
+        payload = check_path(args.path)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
+    print(json.dumps(_empty_operation(args.path, args.operation), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_rich_diagnostics_contract.py
+++ b/tests/test_rich_diagnostics_contract.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from gaussian_lsp import tool
+from gaussian_lsp.agent_lsp import AgentLSP
 from gaussian_lsp.rich_diagnostics import (
     DIAGNOSTIC_CATEGORIES,
     agent_check_payload,
     diagnostic_to_dict,
+    serialize_diagnostics,
+    severity_label,
 )
 
 
@@ -34,3 +44,165 @@ def test_legacy_diagnostic_is_enriched() -> None:
     assert item["blocking"] is True
     assert item["range"]["start"] == {"line": 1, "character": 2}
     assert item["fix_hints"] == []
+
+
+@dataclass
+class _DataclassDiagnostic:
+    code: str
+    severity: int
+    message: str
+    line: int
+    column: int
+    suggested_fix: str
+
+
+class _JsonDiagnostic:
+    def to_json(self) -> dict[str, object]:
+        return {
+            "code": "GAUSSIANJSON",
+            "severity": "Hint",
+            "message": "deprecated route style",
+            "range": {"start_line": 3, "start_col": 4, "end_line": 3, "end_col": 9},
+        }
+
+
+class _BrokenJsonDiagnostic:
+    def to_json(self) -> dict[str, object]:
+        raise TypeError("not serializable")
+
+
+def test_rich_diagnostics_handles_dataclass_json_and_lsp_ranges() -> None:
+    dataclass_item = diagnostic_to_dict(
+        _DataclassDiagnostic(
+            code="GAUSSIANDATA",
+            severity=2,
+            message="memory runtime risk",
+            line=4,
+            column=5,
+            suggested_fix="increase %mem",
+        ),
+        software="gaussian",
+        path="calc.gjf",
+        file_type="gjf",
+    )
+    assert dataclass_item["severity"] == "warning"
+    assert dataclass_item["category"] == "preflight/runtime-risk"
+    assert dataclass_item["fix_hints"] == ["increase %mem"]
+
+    json_item = diagnostic_to_dict(_JsonDiagnostic(), software="gaussian")
+    assert json_item["severity"] == "hint"
+    assert json_item["category"] == "style/deprecation"
+    assert json_item["range"]["start"] == {"line": 3, "character": 4}
+
+    lsp_range = SimpleNamespace(
+        start=SimpleNamespace(line=6, character=7),
+        end=SimpleNamespace(line=6, character=13),
+    )
+    lsp_item = diagnostic_to_dict(
+        SimpleNamespace(
+            range=lsp_range,
+            severity=1,
+            code=None,
+            source="",
+            message="basis file reference missing",
+        ),
+        software="gaussian",
+    )
+    assert lsp_item["category"] == "cross-file reference"
+    assert lsp_item["blocking"] is True
+
+    fallback_item = diagnostic_to_dict(_BrokenJsonDiagnostic(), software="gaussian")
+    assert fallback_item["code"] == "diagnostic"
+    assert severity_label("info") == "information"
+
+
+def test_serialize_diagnostics_is_stable() -> None:
+    items = serialize_diagnostics(
+        [
+            {"code": "B", "line": 3, "column": 1, "message": "second"},
+            {"code": "A", "line": 1, "column": 1, "message": "first"},
+        ],
+        software="gaussian",
+    )
+    assert [item["code"] for item in items] == ["A", "B"]
+
+
+def test_agent_lsp_text_path_and_reserved_operations(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    calls = []
+
+    def fake_check_path(path):
+        calls.append(path)
+        return {
+            "uri": path.resolve().as_uri(),
+            "operation": "check",
+            "ok": True,
+            "diagnostics": [],
+            "summary": {"blocking": 0},
+        }
+
+    monkeypatch.setattr("gaussian_lsp.agent_lsp.check_path", fake_check_path)
+
+    agent = AgentLSP.from_text("# HF/STO-3G\n\nTitle\n\n0 1\nH 0 0 0\n")
+    payload = agent.check()
+    assert payload["uri"] == "file:///input"
+    assert calls[0].name == "input"
+
+    input_path = tmp_path / "calc.gjf"
+    input_path.write_text("# HF/STO-3G\n\nTitle\n\n0 1\nH 0 0 0\n", encoding="utf-8")
+    path_payload = AgentLSP.from_path(input_path).check()
+    assert path_payload["uri"] == input_path.resolve().as_uri()
+
+    assert agent.context(1, 2)["position"] == {"line": 1, "character": 2}
+    assert agent.complete()["items"] == []
+    assert agent.hover()["contents"] is None
+    assert agent.symbols()["items"] == []
+
+
+def test_tool_main_emits_json_and_fail_on_blocking(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+) -> None:
+    input_path = tmp_path / "calc.gjf"
+    input_path.write_text("# bad\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        tool,
+        "_collect_diagnostics",
+        lambda path: [
+            {
+                "code": "GAUSSIAN001",
+                "severity": "error",
+                "message": "unknown keyword",
+                "line": 1,
+                "column": 1,
+            }
+        ],
+    )
+
+    payload = tool.check_path(input_path)
+    assert payload["software"] == "gaussian"
+    assert payload["diagnostics"][0]["file_type"] == "gjf"
+    assert payload["ok"] is False
+
+    assert tool.main(["check", str(input_path)]) == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["blocking"] == 1
+
+    assert tool.main(["check", str(input_path), "--fail-on-blocking"]) == 1
+    capsys.readouterr()
+
+    assert tool.main(["hover", str(input_path)]) == 0
+    reserved = json.loads(capsys.readouterr().out)
+    assert reserved["operation"] == "hover"
+    assert "reserved" in reserved["summary"]["note"]
+
+
+def test_tool_collect_diagnostics_and_file_type_smoke(tmp_path) -> None:
+    input_path = tmp_path / "calc.gjf"
+    input_path.write_text("# HF/STO-3G\n\nTitle\n\n0 1\nH 0 0 0\n", encoding="utf-8")
+
+    assert isinstance(tool._collect_diagnostics(input_path), list)
+    assert tool._file_type(input_path) == "gjf"
+    assert tool._file_type(tmp_path / "INCAR") == "INCAR"
+    assert tool._file_type(tmp_path / "README") == "readme"

--- a/tests/test_rich_diagnostics_contract.py
+++ b/tests/test_rich_diagnostics_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from gaussian_lsp.rich_diagnostics import (
+    DIAGNOSTIC_CATEGORIES,
+    agent_check_payload,
+    diagnostic_to_dict,
+)
+
+
+def test_diagnostic_engine_v1_contract_shape() -> None:
+    payload = agent_check_payload(
+        software="gaussian",
+        uri="file:///tmp/input",
+        diagnostics=[],
+    )
+    assert payload["diagnostic_engine"] == "1.0"
+    assert payload["ok"] is True
+    assert payload["diagnostics"] == []
+    assert set(DIAGNOSTIC_CATEGORIES) >= {"syntax", "schema", "type/value"}
+
+
+def test_legacy_diagnostic_is_enriched() -> None:
+    diagnostic = {
+        "code": "GAUSSIAN001",
+        "severity": "error",
+        "message": "unknown keyword",
+        "line": 2,
+        "column": 3,
+        "source": "gaussian-lsp",
+    }
+    item = diagnostic_to_dict(diagnostic, software="gaussian", path="input")
+    assert item["severity"] == "error"
+    assert item["category"] == "schema"
+    assert item["blocking"] is True
+    assert item["range"]["start"] == {"line": 1, "character": 2}
+    assert item["fix_hints"] == []


### PR DESCRIPTION
## Summary

- Add Diagnostic Engine v1 rich diagnostic serialization with the unified agent/LSP JSON contract.
- Add an agent-facing Python API and `<software>-lsp-tool check|context|complete|hover|symbols|fix --format json` CLI surface.
- Add `diagnostics/diagnostic-engine-v1.schema.json`, compatibility documentation, and contract tests.

## Verification

- `python3 -m py_compile` on the new diagnostic, tool, and AgentLSP modules.
- Rich diagnostics contract tests pass for this repository.
- CLI JSON smoke was run during rollout for `check --format json` and reserved operations where supported.
- Cross-repo schema JSON validation passed for the Diagnostic Engine v1 schema.
