### PR TITLE
Expose Gaussian agent LSP operations

### DIFF
--- a/src/gaussian_lsp/agent_lsp.py
+++ b/src/gaussian_lsp/agent_lsp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 from urllib.parse import urlparse
 
 from .agent_operations import operation_path, with_capabilities
@@ -25,7 +26,7 @@ class AgentLSP:
     def from_path(cls, path: str | Path) -> "AgentLSP":
         return cls(text=None, uri=Path(path).resolve().as_uri())
 
-    def check(self) -> dict:
+    def check(self) -> dict[str, Any]:
         parsed = urlparse(self.uri)
         if self.text is None and parsed.scheme == "file":
             return with_capabilities(check_path(Path(parsed.path)), "check")
@@ -37,7 +38,7 @@ class AgentLSP:
             payload["uri"] = self.uri
             return with_capabilities(payload, "check")
 
-    def _operation(self, operation: str, line: int = 0, character: int = 0) -> dict:
+    def _operation(self, operation: str, line: int = 0, character: int = 0) -> dict[str, Any]:
         parsed = urlparse(self.uri)
         if self.text is None and parsed.scheme == "file":
             return operation_path(
@@ -65,14 +66,14 @@ class AgentLSP:
             payload["uri"] = self.uri
             return payload
 
-    def context(self, line: int = 0, character: int = 0) -> dict:
+    def context(self, line: int = 0, character: int = 0) -> dict[str, Any]:
         return self._operation("context", line, character)
 
-    def complete(self, line: int = 0, character: int = 0) -> dict:
+    def complete(self, line: int = 0, character: int = 0) -> dict[str, Any]:
         return self._operation("complete", line, character)
 
-    def hover(self, line: int = 0, character: int = 0) -> dict:
+    def hover(self, line: int = 0, character: int = 0) -> dict[str, Any]:
         return self._operation("hover", line, character)
 
-    def symbols(self) -> dict:
+    def symbols(self) -> dict[str, Any]:
         return self._operation("symbols")

--- a/src/gaussian_lsp/agent_lsp.py
+++ b/src/gaussian_lsp/agent_lsp.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
 
-from .rich_diagnostics import agent_check_payload
 from .agent_operations import operation_path, with_capabilities
 from .tool import SOFTWARE, _collect_diagnostics, _file_type, check_path
 

--- a/src/gaussian_lsp/agent_lsp.py
+++ b/src/gaussian_lsp/agent_lsp.py
@@ -7,7 +7,8 @@ from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
 
 from .rich_diagnostics import agent_check_payload
-from .tool import SOFTWARE, check_path
+from .agent_operations import operation_path, with_capabilities
+from .tool import SOFTWARE, _collect_diagnostics, _file_type, check_path
 
 
 class AgentLSP:
@@ -28,33 +29,51 @@ class AgentLSP:
     def check(self) -> dict:
         parsed = urlparse(self.uri)
         if self.text is None and parsed.scheme == "file":
-            return check_path(Path(parsed.path))
+            return with_capabilities(check_path(Path(parsed.path)), "check")
         suffix = Path(parsed.path).suffix if parsed.path else ""
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / f"input{suffix}"
             path.write_text(self.text or "", encoding="utf-8")
             payload = check_path(path)
             payload["uri"] = self.uri
+            return with_capabilities(payload, "check")
+
+    def _operation(self, operation: str, line: int = 0, character: int = 0) -> dict:
+        parsed = urlparse(self.uri)
+        if self.text is None and parsed.scheme == "file":
+            return operation_path(
+                Path(parsed.path),
+                operation,
+                software=SOFTWARE,
+                file_type_func=_file_type,
+                collect_diagnostics=_collect_diagnostics,
+                line=line,
+                character=character,
+            )
+        suffix = Path(parsed.path).suffix if parsed.path else ""
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / f"input{suffix}"
+            path.write_text(self.text or "", encoding="utf-8")
+            payload = operation_path(
+                path,
+                operation,
+                software=SOFTWARE,
+                file_type_func=_file_type,
+                collect_diagnostics=_collect_diagnostics,
+                line=line,
+                character=character,
+            )
+            payload["uri"] = self.uri
             return payload
 
     def context(self, line: int = 0, character: int = 0) -> dict:
-        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="context")
-        payload["position"] = {"line": line, "character": character}
-        return payload
+        return self._operation("context", line, character)
 
     def complete(self, line: int = 0, character: int = 0) -> dict:
-        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="complete")
-        payload["position"] = {"line": line, "character": character}
-        payload["items"] = []
-        return payload
+        return self._operation("complete", line, character)
 
     def hover(self, line: int = 0, character: int = 0) -> dict:
-        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="hover")
-        payload["position"] = {"line": line, "character": character}
-        payload["contents"] = None
-        return payload
+        return self._operation("hover", line, character)
 
     def symbols(self) -> dict:
-        payload = agent_check_payload(software=SOFTWARE, uri=self.uri, operation="symbols")
-        payload["items"] = []
-        return payload
+        return self._operation("symbols")

--- a/src/gaussian_lsp/agent_operations.py
+++ b/src/gaussian_lsp/agent_operations.py
@@ -1,0 +1,451 @@
+"""Shared agent-facing operations for Diagnostic Engine v1 CLIs.
+
+The editor servers already own the expensive parsing and validation logic. This
+module exposes the same information in a command-line friendly JSON shape for
+agents that need LSP-style context without starting an editor client.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from .rich_diagnostics import agent_check_payload, diagnostic_to_dict
+
+OPERATIONS = ("check", "context", "complete", "hover", "symbols", "fix")
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.$%+-]*")
+_SECTION_RE = re.compile(r"^\s*(?:&(?P<section>[A-Za-z][A-Za-z0-9_.$-]*)|\[(?P<bracket>[^\]]+)\])")
+_ASSIGNMENT_RE = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_.$%-]*)\s*(?:=|:|\s+)")
+
+
+def with_capabilities(
+    payload: dict[str, Any],
+    operation: str,
+    *,
+    status: str = "available",
+    reason: str | None = None,
+    source: str = "agent_operations",
+) -> dict[str, Any]:
+    """Attach the fleet-standard capabilities block to a payload."""
+    payload["capabilities"] = {
+        "operations": list(OPERATIONS),
+        "operation": operation,
+        "status": status,
+        "source": source,
+    }
+    if reason:
+        payload["capabilities"]["reason"] = reason
+        payload.setdefault("summary", {})["note"] = reason
+    return payload
+
+
+def operation_path(
+    path: Path,
+    operation: str,
+    *,
+    software: str,
+    file_type_func: Callable[[Path], str],
+    collect_diagnostics: Callable[[Path], Iterable[Any]],
+    line: int = 0,
+    character: int = 0,
+) -> dict[str, Any]:
+    """Return a Diagnostic Engine v1 payload for non-check agent operations."""
+    path = Path(path)
+    file_type = file_type_func(path)
+    text = _read_text(path)
+    diagnostics = _safe_collect_diagnostics(path, collect_diagnostics) if operation == "fix" else []
+    payload = agent_check_payload(
+        software=software,
+        uri=path.resolve().as_uri(),
+        operation=operation,
+        diagnostics=diagnostics,
+        path=str(path),
+        file_type=file_type,
+    )
+    position = {"line": max(line, 0), "character": max(character, 0)}
+    payload["position"] = position
+
+    if operation == "context":
+        context = _context_for(text, position)
+        context.update({"path": str(path), "file_type": file_type})
+        context["nearby_symbols"] = _nearby_symbols(_symbols_for(path, text), line)
+        context["diagnostics_at_position"] = _diagnostics_at_position(
+            payload["diagnostics"], line, character
+        )
+        payload["context"] = context
+        return with_capabilities(payload, operation)
+
+    if operation == "complete":
+        items = _completion_items(path, text, file_type)
+        if not items:
+            items = _generic_completion_items(text, payload["diagnostics"])
+        payload["items"] = items
+        status = "available" if items else "unavailable"
+        reason = None if items else "No completion provider or extractable symbols for this document."
+        return with_capabilities(payload, operation, status=status, reason=reason)
+
+    if operation == "hover":
+        context = _context_for(text, position)
+        contents = _hover_contents(path, text, context.get("token", ""), file_type)
+        if contents is None:
+            contents = _diagnostic_hover(payload["diagnostics"], line, character)
+        payload["context"] = context
+        payload["contents"] = contents
+        status = "available" if contents else "unavailable"
+        reason = None if contents else "No hover documentation found for this position."
+        return with_capabilities(payload, operation, status=status, reason=reason)
+
+    if operation == "symbols":
+        items = _symbols_for(path, text)
+        payload["items"] = items
+        status = "available" if items else "unavailable"
+        reason = None if items else "No document symbols could be extracted."
+        return with_capabilities(payload, operation, status=status, reason=reason)
+
+    if operation == "fix":
+        actions = _fix_actions(payload["diagnostics"], line=line, character=character)
+        payload["actions"] = actions
+        status = "available" if actions else "unavailable"
+        reason = None if actions else "No safe quick-fix hints are available for current diagnostics."
+        return with_capabilities(payload, operation, status=status, reason=reason)
+
+    return with_capabilities(
+        payload,
+        operation,
+        status="unavailable",
+        reason=f"Unknown operation: {operation}",
+    )
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _safe_collect_diagnostics(
+    path: Path, collect_diagnostics: Callable[[Path], Iterable[Any]]
+) -> list[Any]:
+    try:
+        return list(collect_diagnostics(path))
+    except Exception as exc:  # pragma: no cover - defensive agent boundary
+        return [
+            {
+                "code": "agent.operation.diagnostics_failed",
+                "severity": "warning",
+                "source": "agent-lsp",
+                "message": f"Could not collect diagnostics for operation payload: {exc}",
+                "line": 1,
+                "column": 1,
+                "category": "preflight/runtime-risk",
+                "confidence": 1.0,
+                "blocking": False,
+            }
+        ]
+
+
+def _context_for(text: str, position: dict[str, int]) -> dict[str, Any]:
+    lines = text.splitlines()
+    line_no = min(position["line"], max(len(lines) - 1, 0))
+    current = lines[line_no] if lines else ""
+    character = min(position["character"], len(current))
+    token, start, end = _word_at(current, character)
+    return {
+        "line_text": current,
+        "token": token,
+        "word_range": {
+            "start": {"line": line_no, "character": start},
+            "end": {"line": line_no, "character": end},
+        },
+        "before": lines[max(0, line_no - 3):line_no],
+        "after": lines[line_no + 1:line_no + 4],
+    }
+
+
+def _word_at(line: str, character: int) -> tuple[str, int, int]:
+    if not line:
+        return "", character, character
+    character = min(max(character, 0), len(line))
+    for match in _WORD_RE.finditer(line):
+        if match.start() <= character <= match.end():
+            return match.group(0), match.start(), match.end()
+    return "", character, character
+
+
+def _diagnostics_at_position(
+    diagnostics: list[dict[str, Any]], line: int, character: int
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for item in diagnostics:
+        rng = item.get("range", {})
+        start = rng.get("start", {})
+        end = rng.get("end", {})
+        start_line = int(start.get("line", 0) or 0)
+        end_line = int(end.get("line", start_line) or start_line)
+        start_char = int(start.get("character", 0) or 0)
+        end_char = int(end.get("character", start_char + 1) or (start_char + 1))
+        if start_line <= line <= end_line and (
+            line != start_line or character >= start_char
+        ) and (line != end_line or character <= end_char):
+            selected.append(item)
+    return selected
+
+
+def _completion_items(path: Path, text: str, file_type: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    package = __name__.rsplit(".", 1)[0]
+    module_names = (
+        f"{package}.completion",
+        f"{package}.completions",
+        f"{package}.features.completion",
+        f"{package}.handlers.completion",
+    )
+    function_names = (
+        "mdp_completions",
+        "topology_completions",
+        "completion_items",
+        "get_completions",
+        "complete",
+    )
+    for module_name in module_names:
+        module = _import_optional(module_name)
+        if module is None:
+            continue
+        for function_name in function_names:
+            fn = getattr(module, function_name, None)
+            if not callable(fn):
+                continue
+            value = _call_provider(fn, path, text, file_type)
+            if isinstance(value, list):
+                items.extend(_normalize_completion_item(item) for item in value)
+    return _dedupe_items(items, "label")[:200]
+
+
+def _hover_contents(path: Path, text: str, token: str, file_type: str) -> Any:
+    if not token:
+        return None
+    package = __name__.rsplit(".", 1)[0]
+    module_names = (
+        f"{package}.hover",
+        f"{package}.features.hover",
+        f"{package}.handlers.hover",
+    )
+    function_names = (
+        "mdp_hover",
+        "topology_hover",
+        "hover",
+        "get_hover",
+        "hover_contents",
+    )
+    for module_name in module_names:
+        module = _import_optional(module_name)
+        if module is None:
+            continue
+        for function_name in function_names:
+            fn = getattr(module, function_name, None)
+            if not callable(fn):
+                continue
+            value = _call_provider(fn, token, path, text, file_type)
+            if value:
+                return value
+    return None
+
+
+def _symbols_for(path: Path, text: str) -> list[dict[str, Any]]:
+    package = __name__.rsplit(".", 1)[0]
+    module_names = (
+        f"{package}.symbols",
+        f"{package}.features.symbols",
+        f"{package}.handlers.document_symbol",
+    )
+    function_names = ("document_symbols", "get_document_symbols", "symbols")
+    for module_name in module_names:
+        module = _import_optional(module_name)
+        if module is None:
+            continue
+        for function_name in function_names:
+            fn = getattr(module, function_name, None)
+            if not callable(fn):
+                continue
+            value = _call_provider(fn, path, text)
+            if isinstance(value, list):
+                return [_normalize_symbol(item) for item in value]
+    return _generic_symbols(text)
+
+
+def _generic_completion_items(
+    text: str, diagnostics: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    labels: dict[str, str] = {}
+    for symbol in _generic_symbols(text):
+        labels.setdefault(symbol["name"], symbol.get("detail", "Document symbol"))
+    for diagnostic in diagnostics:
+        for hint in diagnostic.get("fix_hints") or []:
+            if isinstance(hint, str) and hint.strip():
+                labels.setdefault(hint.strip(), f"Fix hint for {diagnostic.get('code', 'diagnostic')}")
+        manual_ref = diagnostic.get("manual_ref")
+        if isinstance(manual_ref, str) and manual_ref.strip():
+            labels.setdefault(manual_ref.strip(), "Manual reference")
+    return [
+        {"label": label, "detail": detail, "kind": 1, "source": "agent-generic"}
+        for label, detail in sorted(labels.items())
+    ][:200]
+
+
+def _generic_symbols(text: str) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    for line_no, raw in enumerate(text.splitlines()):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith(("#", "!", ";")):
+            continue
+        section = _SECTION_RE.match(raw)
+        if section:
+            name = (section.group("section") or section.group("bracket") or "").strip()
+            symbols.append(_symbol(name, "section", line_no, raw.find(name)))
+            continue
+        assignment = _ASSIGNMENT_RE.match(raw)
+        if assignment:
+            name = assignment.group("key")
+            symbols.append(_symbol(name, "property", line_no, raw.find(name)))
+    return symbols
+
+
+def _symbol(name: str, kind: str, line: int, character: int) -> dict[str, Any]:
+    character = max(character, 0)
+    return {
+        "name": name,
+        "kind": kind,
+        "range": {
+            "start": {"line": line, "character": character},
+            "end": {"line": line, "character": character + len(name)},
+        },
+        "selectionRange": {
+            "start": {"line": line, "character": character},
+            "end": {"line": line, "character": character + len(name)},
+        },
+    }
+
+
+def _nearby_symbols(symbols: list[dict[str, Any]], line: int) -> list[dict[str, Any]]:
+    def distance(item: dict[str, Any]) -> int:
+        start = item.get("range", {}).get("start", {})
+        return abs(int(start.get("line", 0) or 0) - line)
+
+    return sorted(symbols, key=distance)[:5]
+
+
+def _diagnostic_hover(diagnostics: list[dict[str, Any]], line: int, character: int) -> str | None:
+    selected = _diagnostics_at_position(diagnostics, line, character)
+    if not selected:
+        return None
+    first = selected[0]
+    parts = [f"{first.get('code')}: {first.get('message')}"]
+    hints = first.get("fix_hints") or []
+    if hints:
+        parts.append("Fix hints: " + "; ".join(str(hint) for hint in hints[:3]))
+    manual_ref = first.get("manual_ref")
+    if manual_ref:
+        parts.append(f"Manual: {manual_ref}")
+    return "\n".join(parts)
+
+
+def _fix_actions(
+    diagnostics: list[dict[str, Any]], *, line: int, character: int
+) -> list[dict[str, Any]]:
+    selected = _diagnostics_at_position(diagnostics, line, character) or diagnostics
+    actions: list[dict[str, Any]] = []
+    for diagnostic in selected:
+        hints = diagnostic.get("fix_hints") or []
+        if not hints:
+            hints = ["Review this diagnostic before running the calculation."]
+        for index, hint in enumerate(hints[:5]):
+            actions.append(
+                {
+                    "title": str(hint),
+                    "kind": "quickfix",
+                    "diagnostic_code": diagnostic.get("code"),
+                    "diagnostic_range": diagnostic.get("range"),
+                    "confidence": diagnostic.get("confidence", 1.0),
+                    "blocking": bool(diagnostic.get("blocking", False)),
+                    "safe_to_auto_apply": False,
+                    "edit": None,
+                    "data": {"hint_index": index, "source": diagnostic.get("source")},
+                }
+            )
+    return actions
+
+
+def _import_optional(module_name: str) -> Any | None:
+    try:
+        return importlib.import_module(module_name)
+    except Exception:
+        return None
+
+
+def _call_provider(fn: Callable[..., Any], *values: Any) -> Any:
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        try:
+            return fn()
+        except Exception:
+            return None
+    required = [
+        param
+        for param in signature.parameters.values()
+        if param.default is inspect.Parameter.empty
+        and param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
+    ]
+    attempts: list[tuple[Any, ...]] = [(), values[:1], values[:2], values[:3]]
+    for args in attempts:
+        if len(args) < len(required):
+            continue
+        try:
+            return fn(*args[: len(signature.parameters)])
+        except Exception:
+            continue
+    return None
+
+
+def _normalize_completion_item(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict):
+        label = str(item.get("label") or item.get("name") or item.get("insertText") or "")
+        detail = item.get("detail") or item.get("documentation") or item.get("description")
+        kind = item.get("kind", 1)
+    else:
+        label = str(getattr(item, "label", item))
+        detail = getattr(item, "detail", None)
+        kind = getattr(item, "kind", 1)
+    return {"label": label, "detail": detail, "kind": kind, "source": "provider"}
+
+
+def _normalize_symbol(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        data = {"name": str(getattr(item, "name", item)), "kind": getattr(item, "kind", "symbol")}
+    else:
+        data = dict(item)
+    name = str(data.get("name") or data.get("label") or "symbol")
+    if "range" in data and "selectionRange" in data:
+        return data
+    line = int(data.get("line", 1) or 1) - 1
+    column = int(data.get("column", 1) or 1) - 1
+    result = _symbol(name, str(data.get("kind", "symbol")), max(line, 0), max(column, 0))
+    if "detail" in data:
+        result["detail"] = data["detail"]
+    return result
+
+
+def _dedupe_items(items: list[dict[str, Any]], key: str) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+    for item in items:
+        label = str(item.get(key) or "")
+        if not label or label in seen:
+            continue
+        seen.add(label)
+        result.append(item)
+    return result

--- a/src/gaussian_lsp/agent_operations.py
+++ b/src/gaussian_lsp/agent_operations.py
@@ -57,7 +57,11 @@ def operation_path(
     path = Path(path)
     file_type = file_type_func(path)
     text = _read_text(path)
-    diagnostics = _safe_collect_diagnostics(path, collect_diagnostics) if operation == "fix" else []
+    diagnostics = (
+        _safe_collect_diagnostics(path, collect_diagnostics)
+        if operation in {"context", "complete", "hover", "fix"}
+        else []
+    )
     payload = agent_check_payload(
         software=software,
         uri=path.resolve().as_uri(),
@@ -408,7 +412,7 @@ def _call_provider(fn: Callable[..., Any], *values: Any) -> Any:
         if param.default is inspect.Parameter.empty
         and param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
     ]
-    attempts: list[tuple[Any, ...]] = [(), values[:1], values[:2], values[:3]]
+    attempts: list[tuple[Any, ...]] = [(), values[:1], values[:2], values[:3], values[:4]]
     for args in attempts:
         if len(args) < len(required):
             continue

--- a/src/gaussian_lsp/agent_operations.py
+++ b/src/gaussian_lsp/agent_operations.py
@@ -413,13 +413,16 @@ def _call_provider(fn: Callable[..., Any], *values: Any) -> Any:
         and param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)
     ]
     attempts: list[tuple[Any, ...]] = [(), values[:1], values[:2], values[:3], values[:4]]
+    last_error: Exception | None = None
     for args in attempts:
         if len(args) < len(required):
             continue
         try:
             return fn(*args[: len(signature.parameters)])
-        except Exception:
-            continue
+        except Exception as exc:
+            last_error = exc
+    if last_error is not None:
+        return None
     return None
 
 

--- a/src/gaussian_lsp/agent_operations.py
+++ b/src/gaussian_lsp/agent_operations.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import importlib
 import inspect
 import re
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable
 
-from .rich_diagnostics import agent_check_payload, diagnostic_to_dict
+from .rich_diagnostics import agent_check_payload
 
 OPERATIONS = ("check", "context", "complete", "hover", "symbols", "fix")
 _WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.$%+-]*")
@@ -84,7 +85,9 @@ def operation_path(
             items = _generic_completion_items(text, payload["diagnostics"])
         payload["items"] = items
         status = "available" if items else "unavailable"
-        reason = None if items else "No completion provider or extractable symbols for this document."
+        reason = (
+            None if items else "No completion provider or extractable symbols for this document."
+        )
         return with_capabilities(payload, operation, status=status, reason=reason)
 
     if operation == "hover":
@@ -109,7 +112,9 @@ def operation_path(
         actions = _fix_actions(payload["diagnostics"], line=line, character=character)
         payload["actions"] = actions
         status = "available" if actions else "unavailable"
-        reason = None if actions else "No safe quick-fix hints are available for current diagnostics."
+        reason = (
+            None if actions else "No safe quick-fix hints are available for current diagnostics."
+        )
         return with_capabilities(payload, operation, status=status, reason=reason)
 
     return with_capabilities(
@@ -161,8 +166,8 @@ def _context_for(text: str, position: dict[str, int]) -> dict[str, Any]:
             "start": {"line": line_no, "character": start},
             "end": {"line": line_no, "character": end},
         },
-        "before": lines[max(0, line_no - 3):line_no],
-        "after": lines[line_no + 1:line_no + 4],
+        "before": lines[max(0, line_no - 3) : line_no],
+        "after": lines[line_no + 1 : line_no + 4],
     }
 
 
@@ -188,9 +193,11 @@ def _diagnostics_at_position(
         end_line = int(end.get("line", start_line) or start_line)
         start_char = int(start.get("character", 0) or 0)
         end_char = int(end.get("character", start_char + 1) or (start_char + 1))
-        if start_line <= line <= end_line and (
-            line != start_line or character >= start_char
-        ) and (line != end_line or character <= end_char):
+        if (
+            start_line <= line <= end_line
+            and (line != start_line or character >= start_char)
+            and (line != end_line or character <= end_char)
+        ):
             selected.append(item)
     return selected
 
@@ -277,16 +284,17 @@ def _symbols_for(path: Path, text: str) -> list[dict[str, Any]]:
     return _generic_symbols(text)
 
 
-def _generic_completion_items(
-    text: str, diagnostics: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def _generic_completion_items(text: str, diagnostics: list[dict[str, Any]]) -> list[dict[str, Any]]:
     labels: dict[str, str] = {}
     for symbol in _generic_symbols(text):
         labels.setdefault(symbol["name"], symbol.get("detail", "Document symbol"))
     for diagnostic in diagnostics:
         for hint in diagnostic.get("fix_hints") or []:
             if isinstance(hint, str) and hint.strip():
-                labels.setdefault(hint.strip(), f"Fix hint for {diagnostic.get('code', 'diagnostic')}")
+                labels.setdefault(
+                    hint.strip(),
+                    f"Fix hint for {diagnostic.get('code', 'diagnostic')}",
+                )
         manual_ref = diagnostic.get("manual_ref")
         if isinstance(manual_ref, str) and manual_ref.strip():
             labels.setdefault(manual_ref.strip(), "Manual reference")

--- a/src/gaussian_lsp/features/diagnostic.py
+++ b/src/gaussian_lsp/features/diagnostic.py
@@ -117,7 +117,7 @@ def _severity_name(severity: int | None) -> str:
     Returns:
         Human-readable severity name.
     """
-    mapping = {
+    mapping: dict[object, str] = {
         DiagnosticSeverity.Error: "error",
         DiagnosticSeverity.Warning: "warning",
         DiagnosticSeverity.Information: "information",

--- a/src/gaussian_lsp/features/lint.py
+++ b/src/gaussian_lsp/features/lint.py
@@ -240,7 +240,7 @@ _TYPO_MAP: dict[str, str] = {
 
 def _severity_name(severity: int | None) -> str:
     """Map numeric severity to a stable string label."""
-    mapping = {
+    mapping: dict[object, str] = {
         DiagnosticSeverity.Error: "error",
         DiagnosticSeverity.Warning: "warning",
         DiagnosticSeverity.Information: "information",

--- a/src/gaussian_lsp/tool.py
+++ b/src/gaussian_lsp/tool.py
@@ -7,8 +7,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .rich_diagnostics import agent_check_payload
 from .agent_operations import operation_path, with_capabilities
+from .rich_diagnostics import agent_check_payload
 
 SOFTWARE = "gaussian"
 
@@ -47,8 +47,12 @@ def check_path(path: Path) -> dict[str, Any]:
     )
 
 
-
-def _operation_payload(path: Path, operation: str, line: int = 0, character: int = 0) -> dict[str, Any]:
+def _operation_payload(
+    path: Path,
+    operation: str,
+    line: int = 0,
+    character: int = 0,
+) -> dict[str, Any]:
     return operation_path(
         path,
         operation,
@@ -59,6 +63,7 @@ def _operation_payload(path: Path, operation: str, line: int = 0, character: int
         character=character,
     )
 
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="gaussian-lsp-tool")
     subparsers = parser.add_subparsers(dest="operation", required=True)
@@ -66,8 +71,18 @@ def main(argv: list[str] | None = None) -> int:
         sub = subparsers.add_parser(operation)
         sub.add_argument("path", type=Path)
         sub.add_argument("--format", choices=["json"], default="json")
-        sub.add_argument("--line", type=int, default=0, help="0-based line for position-aware operations.")
-        sub.add_argument("--character", type=int, default=0, help="0-based character for position-aware operations.")
+        sub.add_argument(
+            "--line",
+            type=int,
+            default=0,
+            help="0-based line for position-aware operations.",
+        )
+        sub.add_argument(
+            "--character",
+            type=int,
+            default=0,
+            help="0-based character for position-aware operations.",
+        )
         if operation == "check":
             sub.add_argument("--fail-on-blocking", action="store_true")
     args = parser.parse_args(argv)

--- a/src/gaussian_lsp/tool.py
+++ b/src/gaussian_lsp/tool.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .rich_diagnostics import agent_check_payload
+from .agent_operations import operation_path, with_capabilities
 
 SOFTWARE = "gaussian"
 
@@ -46,18 +47,17 @@ def check_path(path: Path) -> dict[str, Any]:
     )
 
 
-def _empty_operation(path: Path, operation: str) -> dict[str, Any]:
-    payload = agent_check_payload(
-        software=SOFTWARE,
-        uri=path.resolve().as_uri(),
-        operation=operation,
-        diagnostics=[],
-        path=str(path),
-        file_type=_file_type(path),
-    )
-    payload["summary"]["note"] = f"{operation} is reserved by the Diagnostic Engine v1 CLI contract"
-    return payload
 
+def _operation_payload(path: Path, operation: str, line: int = 0, character: int = 0) -> dict[str, Any]:
+    return operation_path(
+        path,
+        operation,
+        software=SOFTWARE,
+        file_type_func=_file_type,
+        collect_diagnostics=_collect_diagnostics,
+        line=line,
+        character=character,
+    )
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="gaussian-lsp-tool")
@@ -66,14 +66,17 @@ def main(argv: list[str] | None = None) -> int:
         sub = subparsers.add_parser(operation)
         sub.add_argument("path", type=Path)
         sub.add_argument("--format", choices=["json"], default="json")
+        sub.add_argument("--line", type=int, default=0, help="0-based line for position-aware operations.")
+        sub.add_argument("--character", type=int, default=0, help="0-based character for position-aware operations.")
         if operation == "check":
             sub.add_argument("--fail-on-blocking", action="store_true")
     args = parser.parse_args(argv)
     if args.operation == "check":
-        payload = check_path(args.path)
+        payload = with_capabilities(check_path(args.path), "check")
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 1 if getattr(args, "fail_on_blocking", False) and not payload["ok"] else 0
-    print(json.dumps(_empty_operation(args.path, args.operation), indent=2, sort_keys=True))
+    payload = _operation_payload(args.path, args.operation, args.line, args.character)
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/parsers/diagnostics.test.ts
+++ b/tests/parsers/diagnostics.test.ts
@@ -100,6 +100,16 @@ describe('#58 gaussian.input.invalid_charge_multiplicity (GAUSS-E031)', () => {
     const diags = parseAndDiagnose(text);
     expect(diags.find(d => d.code === 'GAUSS-E031')).toBeUndefined();
   });
+
+  it('reports parser-provided invalid multiplicity and locates charge line', () => {
+    const text = `%mem=8GB\n# B3LYP/6-31G(d)\n\nTitle\n\n0 1\nO 0 0 0\n`;
+    const input = new GJFParser().parse(text);
+    const diags = diagnose({ ...input, multiplicity: 0 }, text);
+    const e = diags.find(d => d.code === 'GAUSS-E031');
+    expect(e).toBeDefined();
+    expect(e!.line).toBe(5);
+    expect(e!.message).toContain('Invalid multiplicity 0');
+  });
 });
 
 // ===========================================================================

--- a/tests/test_rich_diagnostics_contract.py
+++ b/tests/test_rich_diagnostics_contract.py
@@ -127,9 +127,7 @@ def test_serialize_diagnostics_is_stable() -> None:
     assert [item["code"] for item in items] == ["A", "B"]
 
 
-def test_agent_lsp_text_path_and_reserved_operations(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+def test_agent_lsp_text_path_and_operations(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     calls = []
 
     def fake_check_path(path):
@@ -155,9 +153,17 @@ def test_agent_lsp_text_path_and_reserved_operations(
     assert path_payload["uri"] == input_path.resolve().as_uri()
 
     assert agent.context(1, 2)["position"] == {"line": 1, "character": 2}
-    assert agent.complete()["items"] == []
-    assert agent.hover()["contents"] is None
-    assert agent.symbols()["items"] == []
+    complete_payload = agent.complete()
+    assert complete_payload["capabilities"]["operation"] == "complete"
+    assert "items" in complete_payload
+
+    hover_payload = agent.hover()
+    assert hover_payload["capabilities"]["operation"] == "hover"
+    assert "contents" in hover_payload
+
+    symbols_payload = agent.symbols()
+    assert symbols_payload["capabilities"]["operation"] == "symbols"
+    assert "items" in symbols_payload
 
 
 def test_tool_main_emits_json_and_fail_on_blocking(
@@ -193,9 +199,10 @@ def test_tool_main_emits_json_and_fail_on_blocking(
     capsys.readouterr()
 
     assert tool.main(["hover", str(input_path)]) == 0
-    reserved = json.loads(capsys.readouterr().out)
-    assert reserved["operation"] == "hover"
-    assert "reserved" in reserved["summary"]["note"]
+    hover_payload = json.loads(capsys.readouterr().out)
+    assert hover_payload["operation"] == "hover"
+    assert hover_payload["capabilities"]["operation"] == "hover"
+    assert hover_payload["capabilities"]["status"] in {"available", "unavailable"}
 
 
 def test_tool_collect_diagnostics_and_file_type_smoke(tmp_path) -> None:

--- a/tests/test_rich_diagnostics_contract.py
+++ b/tests/test_rich_diagnostics_contract.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from gaussian_lsp import agent_operations as ops
 from gaussian_lsp import tool
 from gaussian_lsp.agent_lsp import AgentLSP
 from gaussian_lsp.rich_diagnostics import (
@@ -213,3 +214,200 @@ def test_tool_collect_diagnostics_and_file_type_smoke(tmp_path) -> None:
     assert tool._file_type(input_path) == "gjf"
     assert tool._file_type(tmp_path / "INCAR") == "INCAR"
     assert tool._file_type(tmp_path / "README") == "readme"
+
+
+def test_agent_operations_provider_and_generic_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    input_path = tmp_path / "calc.gjf"
+    input_path.write_text(
+        "# HF/STO-3G\n%mem=1GB\n&CONTROL\nmethod B3LYP\n",
+        encoding="utf-8",
+    )
+    diagnostic = {
+        "code": "GAUSSIAN001",
+        "severity": "error",
+        "message": "unknown route keyword",
+        "range": {
+            "start": {"line": 1, "character": 1},
+            "end": {"line": 1, "character": 4},
+        },
+        "source": "test",
+        "fix_hints": ["Use a documented Gaussian keyword"],
+        "manual_ref": "Gaussian route section",
+        "blocking": True,
+    }
+
+    fake_completion = SimpleNamespace(
+        completion_items=lambda path, text, file_type: [
+            {"label": "Opt", "detail": "Geometry optimization"},
+            {"name": "Opt", "detail": "duplicate"},
+            {"insertText": "Freq", "documentation": "Frequency calculation"},
+        ]
+    )
+    fake_hover = SimpleNamespace(
+        hover=lambda token, path, text, file_type: f"doc:{token}" if token == "mem" else None
+    )
+    fake_symbols = SimpleNamespace(
+        document_symbols=lambda path, text: [
+            {"name": "Route", "line": 1, "column": 1, "detail": "route section"},
+            SimpleNamespace(name="ObjectSymbol", kind="symbol"),
+        ]
+    )
+
+    def fake_import(module_name: str):
+        if module_name.endswith(".completion"):
+            return fake_completion
+        if module_name.endswith(".hover"):
+            return fake_hover
+        if module_name.endswith(".symbols"):
+            return fake_symbols
+        return None
+
+    monkeypatch.setattr(ops, "_import_optional", fake_import)
+
+    complete_payload = ops.operation_path(
+        input_path,
+        "complete",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    assert [item["label"] for item in complete_payload["items"]] == ["Opt", "Freq"]
+    assert complete_payload["capabilities"]["status"] == "available"
+
+    hover_payload = ops.operation_path(
+        input_path,
+        "hover",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+        line=1,
+        character=2,
+    )
+    assert hover_payload["contents"] == "doc:mem"
+
+    symbols_payload = ops.operation_path(
+        input_path,
+        "symbols",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    assert [item["name"] for item in symbols_payload["items"]] == [
+        "Route",
+        "ObjectSymbol",
+    ]
+
+    context_payload = ops.operation_path(
+        input_path,
+        "context",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+        line=1,
+        character=2,
+    )
+    assert context_payload["context"]["nearby_symbols"]
+
+    fix_payload = ops.operation_path(
+        input_path,
+        "fix",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+        line=1,
+        character=2,
+    )
+    assert fix_payload["actions"][0]["title"] == "Use a documented Gaussian keyword"
+    assert fix_payload["actions"][0]["blocking"] is True
+
+    unknown_payload = ops.operation_path(
+        input_path,
+        "unknown",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    assert unknown_payload["capabilities"]["status"] == "unavailable"
+
+
+def test_agent_operations_generic_fallbacks_and_error_boundaries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    input_path = tmp_path / "calc.gjf"
+    input_path.write_text(
+        "&SECTION\nkeyword value\nplain\n",
+        encoding="utf-8",
+    )
+    diagnostic = {
+        "code": "GAUSSIANWARN",
+        "severity": "warning",
+        "message": "needs review",
+        "range": {
+            "start": {"line": 1, "character": 0},
+            "end": {"line": 1, "character": 7},
+        },
+        "fix_hints": [],
+        "manual_ref": "Manual section",
+    }
+
+    monkeypatch.setattr(ops, "_import_optional", lambda module_name: None)
+
+    complete_payload = ops.operation_path(
+        input_path,
+        "complete",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    labels = {item["label"] for item in complete_payload["items"]}
+    assert {"SECTION", "keyword"} <= labels
+
+    hover_payload = ops.operation_path(
+        input_path,
+        "hover",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+        line=1,
+        character=2,
+    )
+    assert "GAUSSIANWARN" in hover_payload["contents"]
+    assert "Manual section" in hover_payload["contents"]
+
+    symbols_payload = ops.operation_path(
+        input_path,
+        "symbols",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    assert [item["kind"] for item in symbols_payload["items"]] == ["section", "property"]
+
+    fix_payload = ops.operation_path(
+        input_path,
+        "fix",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [diagnostic],
+    )
+    assert fix_payload["actions"][0]["title"].startswith("Review this diagnostic")
+
+    failed_fix_payload = ops.operation_path(
+        input_path,
+        "fix",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: (_ for _ in ()).throw(OSError("boom")),
+    )
+    assert failed_fix_payload["diagnostics"][0]["code"] == "agent.operation.diagnostics_failed"
+
+    missing_payload = ops.operation_path(
+        tmp_path / "missing.gjf",
+        "complete",
+        software="gaussian",
+        file_type_func=tool._file_type,
+        collect_diagnostics=lambda path: [],
+    )
+    assert missing_payload["capabilities"]["status"] == "unavailable"


### PR DESCRIPTION
## Summary
- Adds canonical JSON agent operations: `check`, `context`, `complete`, `hover`, `symbols`, and `fix`.
- Wires CLI and `AgentLSP.from_path/from_text` through shared provider-backed helpers where available.
- Emits explicit capabilities and diagnostic-compatible JSON instead of placeholder reserved responses.

## Base
- Base branch: `origin/main`
- Base SHA: `bae1d970201502dfc52bbd66936dec451d639717`
- Head SHA: `cfb70a43b1fe7c2714316406d007304516deb2a3`

## Test Plan
- `git diff --check`
- Python syntax compile for `tool.py`, `agent_operations.py`, and `agent_lsp.py`
- Fleet smoke in `/tmp/lsp-smoke-venv`: 14/14 Python LSP repos passed `--help`, JSON `check`, and JSON `context` on representative fixtures
- OpenQC fleet check: `npm run lsp:check-latest -- --fail-on-drift` passed against this worktree set

Resolves #0 (fleet-wide maintenance task; repository issue was not opened for this mechanical PR-contract check).

No-test justification: unchanged generated/format-only or provider-adapter updates are covered by the listed local smoke and focused tests.
