### PR TITLE
chore: add compiled JS to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ htmlcov/
 *.vsix
 node_modules/
 .vscode/
+
+# Compiled TypeScript output
+src/parsers/*.js
+tests/parsers/*.js


### PR DESCRIPTION
Add `src/parsers/*.js` and `tests/parsers/*.js` to `.gitignore`.

The project uses `tsc --noEmit` for type-checking only — compiled `.js` files alongside `.ts` sources should not be tracked.