### PR TITLE
fix(ci): resolve pre-commit whitespace and PR contract merge-base failures

### DIFF
--- a/.github/workflows/pr-contract.yml
+++ b/.github/workflows/pr-contract.yml
@@ -41,7 +41,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           changed="$(git diff --name-only "origin/${BASE_REF}"...HEAD)"
           printf '%s\n' "$changed"
 

--- a/raw/assets/gaussian-input-format.md
+++ b/raw/assets/gaussian-input-format.md
@@ -38,7 +38,7 @@ Opt job
 
 0 1
 atomic coordinates...
-                    
+
 3 8    Add a bond and an angle to the internal
 2 1 3  coordinates used during the geom. opt.
 ```

--- a/tests/test_repo_governance.py
+++ b/tests/test_repo_governance.py
@@ -1,0 +1,42 @@
+"""Repository governance and docs asset checks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_governance_guidance_files_exist() -> None:
+    required = (
+        "AGENTS.md",
+        "CONTRIBUTING.md",
+        ".governance-kit.yml",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        "docs/LLM-WIKI-PLAN.md",
+    )
+    missing = [path for path in required if not (REPO_ROOT / path).is_file()]
+    assert not missing, f"Missing governance files: {', '.join(missing)}"
+
+
+def test_raw_assets_markdown_has_no_trailing_whitespace() -> None:
+    assets_dir = REPO_ROOT / "raw" / "assets"
+    assert assets_dir.is_dir(), "raw/assets directory is missing"
+
+    trailing = re.compile(r"[ \t]+$")
+    violations: list[str] = []
+
+    for path in sorted(assets_dir.glob("*.md")):
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if trailing.search(line):
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{line_no}")
+
+    assert not violations, "Trailing whitespace found:\n" + "\n".join(violations)
+
+
+def test_pr_contract_fetch_has_merge_base() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "pr-contract.yml").read_text(
+        encoding="utf-8"
+    )
+    assert 'git fetch origin "$BASE_REF" --depth=1' not in workflow

--- a/tests/test_repo_governance.py
+++ b/tests/test_repo_governance.py
@@ -36,7 +36,5 @@ def test_raw_assets_markdown_has_no_trailing_whitespace() -> None:
 
 
 def test_pr_contract_fetch_has_merge_base() -> None:
-    workflow = (REPO_ROOT / ".github" / "workflows" / "pr-contract.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = (REPO_ROOT / ".github" / "workflows" / "pr-contract.yml").read_text(encoding="utf-8")
     assert 'git fetch origin "$BASE_REF" --depth=1' not in workflow


### PR DESCRIPTION
## Summary

Fixes two CI failures that broke checks on PR #74:

1. **Trailing whitespace** in `raw/assets/gaussian-input-format.md` — removed trailing spaces that caused the `pre-commit trailing-whitespace` hook to fail.
2. **`--depth=1` in PR contract workflow** — the shallow fetch prevented git from finding a merge base when diffing against main, causing the PR contract check to fail with "no merge base" error. Removed `--depth=1` from the `git fetch` in `.github/workflows/pr-contract.yml`.

Also adds `tests/test_repo_governance.py` with 3 regression tests to guard against regressions.

## TDD Evidence

```
$ python3 -m pytest tests/test_repo_governance.py -v --no-cov
tests/test_repo_governance.py::test_governance_guidance_files_exist PASSED   [ 33%]
tests/test_repo_governance.py::test_raw_assets_markdown_has_no_trailing_whitespace PASSED [ 66%]
tests/test_repo_governance.py::test_pr_contract_fetch_has_merge_base PASSED   [100%]
============================== 3 passed in 0.01s ==============================
```

## Test Plan

- [x] `test_governance_guidance_files_exist` — verifies required governance files are present
- [x] `test_raw_assets_markdown_has_no_trailing_whitespace` — enforces no trailing whitespace in raw/assets markdown
- [x] `test_pr_contract_fetch_has_merge_base` — ensures PR contract workflow never uses `--depth=1` on the base ref fetch

Fixes #74
