### PR TITLE
Package gaussian for pip and pluggable skill export

### DIFF
--- a/.github/workflows/testpypi-release.yml
+++ b/.github/workflows/testpypi-release.yml
@@ -1,0 +1,118 @@
+name: TestPyPI release
+
+on:
+  push:
+    tags:
+      - "testpypi-v*"
+  workflow_dispatch:
+    inputs:
+      publish_to_testpypi:
+        description: "Publish the built artifacts to TestPyPI"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        if: ${{ hashFiles('package.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Rust
+        if: ${{ hashFiles('Cargo.toml') != '' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check tag version
+        if: ${{ startsWith(github.ref, 'refs/tags/testpypi-v') }}
+        run: |
+          python - "${GITHUB_REF_NAME#testpypi-v}" <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          actual = (
+              data.get("project", {}).get("version")
+              or data.get("tool", {}).get("poetry", {}).get("version")
+          )
+          if actual is None and Path("setup.py").exists():
+              match = re.search(
+                  r"version\s*=\s*['\"]([^'\"]+)['\"]",
+                  Path("setup.py").read_text(),
+              )
+              actual = match.group(1) if match else None
+          if actual != expected:
+              raise SystemExit(
+                  f"tag version {expected!r} does not match package version {actual!r}"
+              )
+          PY
+
+      - name: Build artifacts
+        run: scripts/build-testpypi-artifacts.sh
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    if: >-
+      ${{
+        startsWith(github.ref, 'refs/tags/testpypi-v')
+        || (github.event_name == 'workflow_dispatch'
+            && inputs.publish_to_testpypi)
+      }}
+    runs-on: ubuntu-latest
+    environment: testpypi
+    env:
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI with token secret
+        if: ${{ env.TEST_PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          password: ${{ env.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+          attestations: false
+
+      - name: Publish to TestPyPI with trusted publishing
+        if: ${{ env.TEST_PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          skip-existing: true
+          attestations: false

--- a/docs/testpypi-release.md
+++ b/docs/testpypi-release.md
@@ -1,0 +1,64 @@
+# TestPyPI release workflow
+
+This repository publishes prerelease artifacts to TestPyPI only. Do not use this
+workflow for production PyPI releases.
+
+## Local build
+
+```bash
+scripts/build-testpypi-artifacts.sh
+```
+
+The build script writes `dist/`, runs package-specific build steps, validates the
+wheel and sdist with `twine check`, and verifies that the pluggable `skill/`
+metadata is present in the distribution artifacts. CIF repositories use the
+committed JavaScript bundle by default; set `CIF_REBUILD_JS=1` to refresh it
+before building.
+
+## Local TestPyPI upload
+
+Create a TestPyPI API token outside the repository, then run:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD='pypi-...'
+scripts/upload-testpypi.sh
+```
+
+The script defaults to `https://test.pypi.org/legacy/`. Override
+`TWINE_REPOSITORY_URL` only for a compatible private index.
+
+## GitHub tag release
+
+The workflow `.github/workflows/testpypi-release.yml` builds on every
+`testpypi-v*` tag. The tag version must match the package metadata.
+
+For the current prerelease:
+
+```bash
+git tag testpypi-v0.2.12rc1
+git push origin testpypi-v0.2.12rc1
+```
+
+The workflow can publish with either:
+
+- `TEST_PYPI_API_TOKEN` repository secret, using a TestPyPI token; or
+- TestPyPI Trusted Publishing configured for this repository, the
+  `testpypi-release.yml` workflow, and the `testpypi` GitHub environment.
+
+Manual runs are supported from the GitHub Actions tab. Leave
+`publish_to_testpypi=false` for build-only validation, or set it to `true` to
+publish.
+
+## Test install
+
+After publishing:
+
+```bash
+python -m venv /tmp/gaussian-lsp-testpypi
+/tmp/gaussian-lsp-testpypi/bin/python -m pip install --upgrade pip
+/tmp/gaussian-lsp-testpypi/bin/pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  gaussian-lsp==0.2.12rc1
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gaussian-lsp"
-version = "0.2.11"
+version = "0.2.12rc1"
 description = "Language Server Protocol for Gaussian input files"
 readme = "README.md"
 license = {text = "MIT"}
@@ -32,6 +32,10 @@ dev = [
 [project.scripts]
 gaussian-lsp = "gaussian_lsp.server:main"
 gaussian-lsp-tool = "gaussian_lsp.tool:main"
+
+
+[tool.hatch.build.force-include]
+"skill" = "skill"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gaussian_lsp"]

--- a/scripts/build-testpypi-artifacts.sh
+++ b/scripts/build-testpypi-artifacts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+rm -rf dist
+mkdir -p dist
+
+if [[ -f pyproject.toml ]] && grep -q 'build-backend = "maturin"' pyproject.toml; then
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+  uvx maturin build --release --out dist
+  uvx maturin sdist --out dist
+else
+  if [[ -f package.json && -d server/src && -d src/cif_lsp ]]; then
+    if [[ "${CIF_REBUILD_JS:-0}" != "1" \
+      && -s src/cif_lsp/js/cifLspTool.cjs \
+      && -s src/cif_lsp/js/server.cjs ]]; then
+      echo "Using existing bundled CIF JavaScript files."
+    else
+    npm ci --ignore-scripts
+    npm ci --prefix client
+    npm ci --prefix server
+    npm run compile
+    mkdir -p src/cif_lsp/js
+    npx --yes esbuild server/out/cifLspTool.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --outfile=src/cif_lsp/js/cifLspTool.cjs
+    npx --yes esbuild server/out/server.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --banner:js='#!/usr/bin/env node' \
+      --outfile=src/cif_lsp/js/server.cjs
+    chmod 755 src/cif_lsp/js/cifLspTool.cjs
+    fi
+  fi
+  uvx --from build python -m build --outdir dist
+fi
+
+uvx twine check dist/*
+
+"${PYTHON:-python3}" - <<'PY'
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+dist = Path("dist")
+wheels = sorted(dist.glob("*.whl"))
+sdists = sorted(dist.glob("*.tar.gz"))
+if not wheels or not sdists:
+    raise SystemExit("dist must contain at least one wheel and one sdist")
+
+for wheel in wheels:
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+    has_skill = any(name.endswith("skill/skill.yaml") for name in names)
+    has_embedded_skill_cli = any(
+        name.endswith(".data/scripts/lammps-lsp-tool")
+        or name.endswith("/lammps-lsp-tool")
+        for name in names
+    )
+    if not has_skill and not has_embedded_skill_cli:
+        raise SystemExit(f"{wheel} does not expose skill metadata")
+
+for sdist in sdists:
+    with tarfile.open(sdist) as archive:
+        names = archive.getnames()
+    if not any(name.endswith("/skill/skill.yaml") for name in names):
+        raise SystemExit(f"{sdist} does not include skill/skill.yaml")
+
+print("dist artifact checks passed", file=sys.stderr)
+PY

--- a/scripts/upload-testpypi.sh
+++ b/scripts/upload-testpypi.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+if ! compgen -G "dist/*" >/dev/null; then
+  scripts/build-testpypi-artifacts.sh
+fi
+
+if [[ "${TWINE_USERNAME:-}" == "" || "${TWINE_PASSWORD:-}" == "" ]]; then
+  cat >&2 <<'EOF'
+Missing local TestPyPI credentials.
+
+Use a TestPyPI API token:
+  export TWINE_USERNAME=__token__
+  export TWINE_PASSWORD='pypi-...'
+
+GitHub Actions can publish without local credentials when TestPyPI Trusted
+Publishing is configured for .github/workflows/testpypi-release.yml.
+EOF
+  exit 2
+fi
+
+uvx twine upload \
+  --repository-url "${TWINE_REPOSITORY_URL:-https://test.pypi.org/legacy/}" \
+  "$@" \
+  dist/*

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gaussian
+description: "Gaussian input preflight for generated .gjf/.com job files."
+---
+
+# Gaussian LSP Skill
+
+Use this skill when preparing, repairing, or reviewing Gaussian input files before a run. It provides an installable language server and an agent-facing CLI that reports machine-readable diagnostics.
+
+## Scope
+
+- Input patterns: *.gjf, *.com
+- Server command: `gaussian-lsp`
+- Agent CLI: `gaussian-lsp-tool`
+- Diagnostic contract: `DiagnosticEnvelope/v1`
+
+## Installing the checker
+
+```bash
+pip install gaussian-lsp
+```
+
+This installs the `gaussian-lsp` language server and the `gaussian-lsp-tool` agent CLI from the `gaussian-lsp` Python package.
+
+## Useful inspection commands
+
+```bash
+gaussian-lsp-tool capabilities
+gaussian-lsp-tool skill-spec --format json
+gaussian-lsp-tool skill-export --output ./skill
+gaussian-lsp-tool check <input-file-or-dir> --format json
+gaussian-lsp-tool context <input-file-or-dir> --line 0 --character 0 --format json
+gaussian-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format json
+gaussian-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --format json
+gaussian-lsp-tool symbols <input-file-or-dir> --format json
+gaussian-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format json
+```
+
+`fix` is advisory and must be treated as a preview. Do not blindly apply a repair without preserving the user's scientific intent.
+
+## Validation gate
+
+Before saying generated inputs are ready, run:
+
+```bash
+gaussian-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking
+```
+
+Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocking_findings`, `readiness`, and `reason`.
+
+## Repair rules
+
+1. Validate first and identify the smallest blocking issue.
+2. Fix syntax or schema errors with minimal edits.
+3. Preserve scientific settings unless the user explicitly asks to redesign them.
+4. Re-run the checker after every edit.
+5. Separate syntax, schema, semantic, and runtime-log diagnostics in the final report.

--- a/skill/references/README.md
+++ b/skill/references/README.md
@@ -1,0 +1,3 @@
+# Gaussian LSP Skill References
+
+This directory is reserved for small examples, rule notes, and templates that are safe to ship with the Python package. Keep large manuals and generated indexes in the LSP package proper, not in the pluggable skill artifact.

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -10,8 +10,8 @@ entrypoints:
   server: gaussian-lsp
   tool: gaussian-lsp-tool
 file_patterns:
-  - *.gjf
-  - *.com
+  - "*.gjf"
+  - "*.com"
 operations:
   - capabilities
   - check

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -1,0 +1,31 @@
+schema: scientific-lsp-skill/v1
+name: gaussian
+software: gaussian
+display_name: Gaussian
+description: Gaussian input preflight for generated .gjf/.com job files.
+package:
+  name: gaussian-lsp
+  install: pip install gaussian-lsp
+entrypoints:
+  server: gaussian-lsp
+  tool: gaussian-lsp-tool
+file_patterns:
+  - *.gjf
+  - *.com
+operations:
+  - capabilities
+  - check
+  - context
+  - complete
+  - hover
+  - symbols
+  - fix
+diagnostic_contract: DiagnosticEnvelope/v1
+blocking_policy:
+  mode: warning-only
+  description: Use --fail-on-blocking when generated inputs must be launch-ready.
+source_provenance:
+  -
+    kind: official_docs
+    label: Gaussian input overview
+    url: https://gaussian.com/input/

--- a/src/gaussian_lsp/skill_export.py
+++ b/src/gaussian_lsp/skill_export.py
@@ -1,0 +1,197 @@
+"""Export the bundled pluggable skill specification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SKILL_SPEC_JSON = (
+    '{"schema":"scientific-lsp-skill/v1","name":"gaussian","software":"gaussian",'
+    '"display_name":"Gaussian","description":"Gaussian input preflight for genera'
+    'ted .gjf/.com job files.","package":{"name":"gaussian-lsp","install":"pip in'
+    'stall gaussian-lsp"},"entrypoints":{"server":"gaussian-lsp","tool":"gaussian'
+    '-lsp-tool"},"file_patterns":["*.gjf","*.com"],"operations":["capabilities","'
+    'check","context","complete","hover","symbols","fix"],"diagnostic_contract":"'
+    'DiagnosticEnvelope/v1","blocking_policy":{"mode":"warning-only","description'
+    '":"Use --fail-on-blocking when generated inputs must be launch-ready."},"sou'
+    'rce_provenance":[{"kind":"official_docs","label":"Gaussian input overview","'
+    'url":"https://gaussian.com/input/"}]}'
+)
+
+SKILL_SPEC: dict[str, Any] = json.loads(SKILL_SPEC_JSON)
+
+SKILL_MD_LINES = [
+    '---',
+    'name: gaussian',
+    'description: "Gaussian input preflight for generated .gjf/.com job files."',
+    '---',
+    '',
+    '# Gaussian LSP Skill',
+    '',
+    (
+        'Use this skill when preparing, repairing, or reviewing Gaussian input files '
+        'before a run. It provides an installable language server and an agent-facing'
+        ' CLI that reports machine-readable diagnostics.'
+    ),
+    '',
+    '## Scope',
+    '',
+    '- Input patterns: *.gjf, *.com',
+    '- Server command: `gaussian-lsp`',
+    '- Agent CLI: `gaussian-lsp-tool`',
+    '- Diagnostic contract: `DiagnosticEnvelope/v1`',
+    '',
+    '## Installing the checker',
+    '',
+    '```bash',
+    'pip install gaussian-lsp',
+    '```',
+    '',
+    (
+        'This installs the `gaussian-lsp` language server and the `gaussian-lsp-tool`'
+        ' agent CLI from the `gaussian-lsp` Python package.'
+    ),
+    '',
+    '## Useful inspection commands',
+    '',
+    '```bash',
+    'gaussian-lsp-tool capabilities',
+    'gaussian-lsp-tool skill-spec --format json',
+    'gaussian-lsp-tool skill-export --output ./skill',
+    'gaussian-lsp-tool check <input-file-or-dir> --format json',
+    (
+        'gaussian-lsp-tool context <input-file-or-dir> --line 0 --character 0 --forma'
+        't json'
+    ),
+    (
+        'gaussian-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format '
+        'json'
+    ),
+    (
+        'gaussian-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --form'
+        'at json'
+    ),
+    'gaussian-lsp-tool symbols <input-file-or-dir> --format json',
+    (
+        'gaussian-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format js'
+        'on'
+    ),
+    '```',
+    '',
+    (
+        '`fix` is advisory and must be treated as a preview. Do not blindly apply a r'
+        "epair without preserving the user's scientific intent."
+    ),
+    '',
+    '## Validation gate',
+    '',
+    'Before saying generated inputs are ready, run:',
+    '',
+    '```bash',
+    'gaussian-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking',
+    '```',
+    '',
+    (
+        'Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocki'
+        'ng_findings`, `readiness`, and `reason`.'
+    ),
+    '',
+    '## Repair rules',
+    '',
+    '1. Validate first and identify the smallest blocking issue.',
+    '2. Fix syntax or schema errors with minimal edits.',
+    (
+        '3. Preserve scientific settings unless the user explicitly asks to redesign '
+        'them.'
+    ),
+    '4. Re-run the checker after every edit.',
+    (
+        '5. Separate syntax, schema, semantic, and runtime-log diagnostics in the fin'
+        'al report.'
+    ),
+]
+SKILL_MD = "\n".join(SKILL_MD_LINES) + "\n"
+
+REFERENCES_README_LINES = [
+    '# Gaussian LSP Skill References',
+    '',
+    (
+        'This directory is reserved for small examples, rule notes, and templates tha'
+        't are safe to ship with the Python package. Keep large manuals and generated'
+        ' indexes in the LSP package proper, not in the pluggable skill artifact.'
+    ),
+]
+REFERENCES_README = "\n".join(REFERENCES_README_LINES) + "\n"
+
+
+def _yaml_scalar(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if (
+        not text
+        or any(ch in text for ch in ":#[]{},&*?")
+        or text[0] in "-!@`"
+        or text.endswith(" ")
+        or "\n" in text
+    ):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _to_yaml(value: object, indent: int = 0) -> str:
+    pad = " " * indent
+    if isinstance(value, dict):
+        lines: list[str] = []
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}{key}:")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}{key}: {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        if not value:
+            return f"{pad}[]"
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}-")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}- {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    return f"{pad}{_yaml_scalar(value)}"
+
+
+def skill_spec_text(output_format: str = "json") -> str:
+    if output_format == "json":
+        return json.dumps(SKILL_SPEC, indent=2, sort_keys=True, ensure_ascii=False)
+    if output_format == "yaml":
+        return _to_yaml(SKILL_SPEC) + "\n"
+    raise ValueError(f"unsupported skill spec format: {output_format}")
+
+
+def export_skill(output_dir: Path) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    references_dir = output_dir / "references"
+    references_dir.mkdir(exist_ok=True)
+    (output_dir / "skill.yaml").write_text(skill_spec_text("yaml"), encoding="utf-8")
+    (output_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    (references_dir / "README.md").write_text(REFERENCES_README, encoding="utf-8")
+    return {
+        "ok": True,
+        "schema": SKILL_SPEC["schema"],
+        "name": SKILL_SPEC["name"],
+        "output_dir": str(output_dir),
+        "files": [
+            str(output_dir / "skill.yaml"),
+            str(output_dir / "SKILL.md"),
+            str(references_dir / "README.md"),
+        ],
+    }

--- a/src/gaussian_lsp/tool.py
+++ b/src/gaussian_lsp/tool.py
@@ -9,9 +9,9 @@ from typing import Any
 
 from .agent_operations import operation_path, with_capabilities
 from .rich_diagnostics import agent_check_payload
+from .skill_export import export_skill, skill_spec_text
 
 SOFTWARE = "gaussian"
-
 
 def _file_type(path: Path) -> str:
     name = path.name.upper()
@@ -20,7 +20,6 @@ def _file_type(path: Path) -> str:
     if "." in path.name:
         return path.suffix.lstrip(".").lower()
     return name.lower()
-
 
 def _collect_diagnostics(path: Path) -> list[Any]:
     from .features.diagnostic import DiagnosticProvider
@@ -32,7 +31,6 @@ def _collect_diagnostics(path: Path) -> list[Any]:
     diagnostics.extend(LintProvider(None).lint(text))  # type: ignore[arg-type]
     diagnostics.extend(TypecheckProvider().validate(text))
     return diagnostics
-
 
 def _load_intent(path: Path) -> dict[str, Any] | None:
     """Load the optional preflight intent contract for a case directory.
@@ -51,7 +49,6 @@ def _load_intent(path: Path) -> dict[str, Any] | None:
         return None
     return data if isinstance(data, dict) else None
 
-
 def _looks_like_workspace(path: Path) -> bool:
     """Detect whether a path is a real Gaussian generated-input workspace.
 
@@ -64,7 +61,6 @@ def _looks_like_workspace(path: Path) -> bool:
     from .preflight import looks_like_gaussian_workspace
 
     return looks_like_gaussian_workspace(path)
-
 
 def _collect_preflight(
     path: Path, intent: dict[str, Any] | None
@@ -81,7 +77,6 @@ def _collect_preflight(
     version_assumption = resolve_version_assumption(intent)
     return diagnostics, graph.to_json(), version_assumption
 
-
 def _resolve_input_path(path: Path) -> Path:
     """Resolve the Gaussian input file from a path that may be a dir or .gjf."""
     if path.is_dir():
@@ -97,7 +92,6 @@ def _resolve_input_path(path: Path) -> Path:
                 return candidate
         return path / "input.gjf"
     return path
-
 
 def check_path(path: Path) -> dict[str, Any]:
     uri = path.resolve().as_uri()
@@ -125,13 +119,11 @@ def check_path(path: Path) -> dict[str, Any]:
     )
     return payload
 
-
 # Codes already emitted by the legacy analyzer that overlap with the universal
 # preflight surface. We keep the legacy emission (it carries the existing test
 # contract) and drop the duplicate preflight variant to avoid noisy double
 # reports. The preflight shape is still proven by every other fixture.
 _OVERLAP_CODES_BY_LEGACY: dict[str, set[str]] = {}
-
 
 def _dedupe_preflight(legacy: list[Any], preflight: list[Any]) -> list[Any]:
     """Drop preflight diagnostics whose finding the legacy analyzer already emitted."""
@@ -148,7 +140,6 @@ def _dedupe_preflight(legacy: list[Any], preflight: list[Any]) -> list[Any]:
         for item in preflight
         if (item.get("code") if isinstance(item, dict) else None) not in suppressed_preflight
     ]
-
 
 def preflight_path(path: Path) -> dict[str, Any]:
     """Return a preflight-only payload (universal checks, no legacy analyzer)."""
@@ -171,7 +162,6 @@ def preflight_path(path: Path) -> dict[str, Any]:
         artifacts=graph.to_json(),
     )
     return with_capabilities(payload, "preflight")
-
 
 def manifest_path(path: Path | None = None) -> dict[str, Any]:
     """Return the fleet preflight manifest.
@@ -197,7 +187,6 @@ def manifest_path(path: Path | None = None) -> dict[str, Any]:
                 fixtures = [item for item in data["fixtures"] if isinstance(item, dict)]
     return fleet_manifest(fixtures=fixtures)
 
-
 def _operation_payload(
     path: Path,
     operation: str,
@@ -214,10 +203,15 @@ def _operation_payload(
         character=character,
     )
 
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="gaussian-lsp-tool")
     subparsers = parser.add_subparsers(dest="operation", required=True)
+    capabilities = subparsers.add_parser("capabilities")
+    capabilities.add_argument("--format", choices=["json"], default="json")
+    skill_spec = subparsers.add_parser("skill-spec")
+    skill_spec.add_argument("--format", choices=["json", "yaml"], default="json")
+    skill_export = subparsers.add_parser("skill-export")
+    skill_export.add_argument("--output", type=Path, required=True)
     for operation in (
         "check",
         "preflight",
@@ -257,6 +251,36 @@ def main(argv: list[str] | None = None) -> int:
             sub.add_argument("--fail-on-blocking", action="store_true")
     args = parser.parse_args(argv)
 
+    if args.operation == "capabilities":
+        from .skill_export import SKILL_SPEC
+
+        payload = {
+            "schema": "OpenQCLspCapabilities",
+            "version": 1,
+            "id": SKILL_SPEC["package"]["name"],
+            "software": SKILL_SPEC["software"],
+            "displayName": SKILL_SPEC["display_name"],
+            "executable": SKILL_SPEC["entrypoints"]["server"],
+            "filePatterns": SKILL_SPEC["file_patterns"],
+            "capabilities": ["diagnostics", "rich-diagnostics", "completion", "hover", "symbols", "fix-preview", "pluggable-skill"],
+            "agentCli": {
+                "command": SKILL_SPEC["entrypoints"]["tool"],
+                "operations": SKILL_SPEC["operations"],
+                "jsonFormat": True,
+                "failOnBlocking": True,
+            },
+            "diagnosticContract": SKILL_SPEC["diagnostic_contract"],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.operation == "skill-spec":
+        print(skill_spec_text(args.format))
+        return 0
+    if args.operation == "skill-export":
+        print(json.dumps(export_skill(args.output), indent=2, sort_keys=True))
+        return 0
+
     if args.operation == "check":
         payload = with_capabilities(check_path(args.path), "check")
         print(json.dumps(payload, indent=2, sort_keys=True))
@@ -272,7 +296,6 @@ def main(argv: list[str] | None = None) -> int:
     payload = _operation_payload(args.path, args.operation, args.line, args.character)
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a pluggable `skill/` manifest using `scientific-lsp-skill/v1`.
- Add `gaussian-lsp-tool skill-spec --format json|yaml` and `gaussian-lsp-tool skill-export --output <dir>`.
- Package the skill metadata with the wheel/sdist and bump to the next prerelease version.


## Verification
- `python -m compileall` / `cargo check` as applicable.
- Local wheel/sdist build completed.
- `twine check` passed for generated artifacts.
- Installed-wheel smoke passed for `--help`, `capabilities`, `skill-spec`, `skill-export`, and `check --format json`.

TestPyPI upload is intentionally not included in this PR because credentials are environment-provided and not stored in the repository.
