### PR TITLE
test(gaussian): closed-loop fixtures and OpenQC smoke fixes (#79 #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [Unreleased]
+
+### Added
+- Closed-loop fixture tests (`tests/test_closed_loop_fixtures.py`) for DiagnosticEnvelope/v1, fix previews, and OpenQC smoke evidence (#80).
+- Lint cleanup in `tests/test_lsp_readiness.py` so `make check` passes on the maturity branch.
+
+### Fixed
+- `scripts/openqc_smoke.sh` now checks real runtime modules instead of the removed `analyzer.py` stub.
+
 ## [0.2.11] - 2026-03-05
 
 ### Changed

--- a/scripts/openqc_smoke.sh
+++ b/scripts/openqc_smoke.sh
@@ -71,7 +71,7 @@ done
 # 4. Check source files
 echo ""
 echo "--- 4. Source files ---"
-for f in src/gaussian_lsp/rich_diagnostics.py src/gaussian_lsp/analyzer.py; do
+for f in src/gaussian_lsp/rich_diagnostics.py src/gaussian_lsp/tool.py src/gaussian_lsp/parser/gjf_parser.py; do
     if [ -f "$REPO_ROOT/$f" ]; then
         echo "OK: $f exists"
     else

--- a/tests/test_closed_loop_fixtures.py
+++ b/tests/test_closed_loop_fixtures.py
@@ -1,0 +1,119 @@
+"""Closed-loop fixture tests for agent CLI and DiagnosticEnvelope/v1.
+
+Covers issue #80: valid/invalid golden fixtures, fix previews, manifest/smoke
+evidence, and stable envelope JSON from ``gaussian-lsp-tool check``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gaussian_lsp import tool
+
+FIXTURES = Path(__file__).parent / "fixtures"
+RULES = FIXTURES / "rules"
+LOG_FIXTURES = FIXTURES / "log"
+
+
+class TestDiagnosticEnvelopeV1:
+    @pytest.mark.parametrize(
+        "fixture",
+        ["water_sp.gjf", "formaldehyde_opt_freq.gjf"],
+    )
+    def test_valid_fixtures_have_no_blocking_diagnostics(self, fixture: str, capsys) -> None:
+        rc = tool.main(["check", str(FIXTURES / "valid" / fixture)])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostic_envelope"] == "v1"
+        assert payload["diagnostic_engine"] == "1.0"
+        assert payload["software"] == "gaussian"
+        blocking = [d for d in payload["diagnostics"] if d.get("blocking")]
+        assert blocking == [], f"unexpected blocking: {blocking}"
+
+    def test_invalid_missing_charge_mult_has_blocking_error(self, capsys) -> None:
+        rc = tool.main(["check", str(FIXTURES / "invalid" / "missing_charge_mult.gjf")])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diagnostic_envelope"] == "v1"
+        assert payload["ok"] is False
+        blocking = [d for d in payload["diagnostics"] if d.get("blocking")]
+        assert len(blocking) >= 1
+        assert any(d.get("severity") == "error" for d in blocking)
+
+    def test_invalid_unknown_route_has_warning(self, capsys) -> None:
+        rc = tool.main(["check", str(FIXTURES / "invalid" / "unknown_route_keyword.gjf")])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        warnings = [d for d in payload["diagnostics"] if d.get("severity") in {"warning", "hint"}]
+        assert warnings, "expected at least one advisory diagnostic"
+
+    def test_diagnostics_carry_envelope_fields(self, capsys) -> None:
+        rc = tool.main(["check", str(FIXTURES / "invalid" / "low_memory_nproc.gjf")])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        for diag in payload["diagnostics"]:
+            assert "code" in diag
+            assert "severity" in diag
+            assert "blocking" in diag
+            assert "range" in diag
+            assert diag.get("diagnostic_envelope") == "v1"
+
+
+class TestFixOperation:
+    def test_fix_returns_preview_actions(self, capsys) -> None:
+        rc = tool.main(["fix", str(FIXTURES / "invalid" / "missing_charge_mult.gjf")])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["capabilities"]["operation"] == "fix"
+        assert "actions" in payload
+        assert isinstance(payload["actions"], list)
+
+    def test_fix_on_valid_fixture_is_empty(self, capsys) -> None:
+        rc = tool.main(["fix", str(FIXTURES / "valid" / "water_sp.gjf")])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["actions"] == []
+
+
+class TestRuleFixtureCatalog:
+    @pytest.mark.parametrize("rule_file", sorted(RULES.glob("*.json")))
+    def test_rule_fixture_documents_expected_codes(self, rule_file: Path) -> None:
+        spec = json.loads(rule_file.read_text(encoding="utf-8"))
+        assert "rule" in spec
+        assert "code" in spec
+        assert "expected" in spec
+        assert spec["expected"]["code"] == spec["code"]
+
+
+class TestOpenQCSmokeEvidence:
+    def test_lsp_capabilities_has_provenance_and_openqc(self) -> None:
+        caps_path = Path(__file__).parent.parent / "lsp-capabilities.json"
+        payload = json.loads(caps_path.read_text(encoding="utf-8"))
+        assert payload["openqc"]["lsp_check_family"] is True
+        assert len(payload.get("sourceProvenance", [])) >= 1
+
+    def test_raw_assets_manifest_exists(self) -> None:
+        manifest = Path(__file__).parent.parent / "raw/assets/manifest.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        assert len(data.get("entries", [])) >= 1
+
+    def test_manifest_operation_emits_fleet_manifest(self, capsys) -> None:
+        rc = tool.main(["manifest"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert "capabilities" in payload
+        assert "codes" in payload
+
+    def test_fail_on_blocking_exits_nonzero_for_invalid_fixture(self, capsys) -> None:
+        rc = tool.main(
+            ["check", str(FIXTURES / "invalid" / "missing_charge_mult.gjf"), "--fail-on-blocking"]
+        )
+        assert rc == 1
+
+    def test_log_fixtures_exist_for_runtime_diagnostics(self) -> None:
+        """Log parsing is implemented in TypeScript; Python marks fixtures for CI."""
+        assert (LOG_FIXTURES / "scf_not_converged.out").exists()
+        assert (LOG_FIXTURES / "scf_converged.out").exists()

--- a/tests/test_lsp_readiness.py
+++ b/tests/test_lsp_readiness.py
@@ -17,9 +17,7 @@ from gaussian_lsp.features.code_actions import CodeActionProvider
 from gaussian_lsp.features.definition import DefinitionProvider
 from gaussian_lsp.features.references import ReferencesProvider
 from gaussian_lsp.features.rename import RenameProvider, get_rename_provider
-from gaussian_lsp.parser.gjf_parser import (
-    GJFParser,
-)
+from gaussian_lsp.parser.gjf_parser import GJFParser
 
 # ---------------------------------------------------------------------------
 # Paths

--- a/tests/test_lsp_readiness.py
+++ b/tests/test_lsp_readiness.py
@@ -18,11 +18,6 @@ from gaussian_lsp.features.definition import DefinitionProvider
 from gaussian_lsp.features.references import ReferencesProvider
 from gaussian_lsp.features.rename import RenameProvider, get_rename_provider
 from gaussian_lsp.parser.gjf_parser import (
-    GAUSSIAN_BASIS_SETS,
-    GAUSSIAN_JOB_TYPES,
-    GAUSSIAN_METHODS,
-    VALID_ELEMENTS,
-    GaussianJob,
     GJFParser,
 )
 
@@ -1326,7 +1321,7 @@ class TestRename:
         """Rename angle variable A1."""
         # Position on "A1" in "A1=104.5" (line 11)
         lines = ZMATRIX_INPUT.splitlines()
-        a1_line = next(i for i, l in enumerate(lines) if l.strip().startswith("A1="))
+        a1_line = next(i for i, line in enumerate(lines) if line.strip().startswith("A1="))
         pos = Position(line=a1_line, character=1)
         result = provider.get_rename_edits(ZMATRIX_INPUT, self.URI, pos, "ANGLE")
         assert result is not None
@@ -1453,7 +1448,6 @@ class TestDefinitionCoverageGaps:
         the Z-matrix variable path should return None for the definition itself.
         The route keyword path would then be checked.
         """
-        lines = ZMATRIX_INPUT.splitlines()
         # Line 10 has "R2=0.960" - position on R2
         pos = Position(line=10, character=1)
         result = provider.get_definition(ZMATRIX_INPUT, self.URI, pos)


### PR DESCRIPTION
## Summary
- Adds `tests/test_closed_loop_fixtures.py` exercising `check`, `fix`, `manifest`, and DiagnosticEnvelope/v1 on golden valid/invalid fixtures.
- Repairs `scripts/openqc_smoke.sh` to verify real runtime modules instead of the removed `analyzer.py` stub.
- Clears lint debt in `tests/test_lsp_readiness.py`.

Preview-scope agent utility only; does not claim complete Gaussian 16 coverage.

Fixes #79
Fixes #80

## Test Plan
- [x] `make test` (875 passed)
- [x] `scripts/openqc_smoke.sh`
- [x] Closed-loop valid/invalid/warning/fix/manifest assertions
